### PR TITLE
misc/rpm updated to rpm-4.9.1.1

### DIFF
--- a/misc/rpm/Makefile
+++ b/misc/rpm/Makefile
@@ -1,0 +1,68 @@
+COMMENT =           Red Hat package manager
+
+DISTNAME =          rpm-4.9.1.1
+EXTRACT_SUFX =      .tar.bz2
+CATEGORIES =        misc archivers emulators
+HOMEPAGE =          http://www.rpm.org/
+MAINTAINER =        David Cantrell <david.l.cantrell@gmail.com>
+
+MASTER_SITES =      http://rpm.org/releases/rpm-4.9.x/
+
+WANTLIB +=          bz2 c db lua lzma m magic nspr4 nss3 nssutil3 plc4 \
+                    plds4 popt pthread python2.7 util z
+
+MODULES =           devel/gettext \
+                    lang/python
+RUN_DEPENDS =       security/gnupg
+LIB_DEPENDS =       ${MODPY_LIB_DEPENDS} \
+                    archivers/xz \
+                    databases/db/v4 \
+                    devel/libmagic \
+                    devel/popt \
+                    lang/lua \
+                    security/nss
+
+MODPY_SETUPTOOLS =  No
+
+SEPARATE_BUILD =    simple
+USE_GMAKE =         Yes
+USE_LIBTOOL =       Yes
+AUTOCONF_VERSION =  2.68
+CONFIGURE_STYLE =   autoconf gnu
+CONFIGURE_ARGS +=   --localstatedir=/var \
+                    --enable-static=yes \
+                    --with-external-db \
+                    --enable-python \
+                    --with-lua
+
+RPM_CPPFLAGS =      -I${LOCALBASE}/include \
+                    -I${LOCALBASE}/include/db4 \
+                    -I${LOCALBASE}/include/nspr \
+                    -I${LOCALBASE}/include/nss
+RPM_LDFLAGS =       -L${LOCALBASE}/lib \
+                    -L${LOCALBASE}/lib/db4 \
+                    -L${LOCALBASE}/python${MODPY_VERSION}/config
+CONFIGURE_ENV +=    varprefix=/usr \
+                    PYTHON_VERSION=${MODPY_VERSION} \
+                    GPG=${LOCALBASE}/bin/gpg \
+                    CPPFLAGS="${RPM_CPPFLAGS}" \
+                    LDFLAGS="${RPM_LDFLAGS}"
+
+SHARED_LIBS +=      rpm                       1.0 \
+                    rpmbuild                  1.0 \
+                    rpmio                     0.0 \
+                    rpmsign                   0.0
+
+# GPLv2+
+PERMIT_PACKAGE_CDROM = Yes
+PERMIT_PACKAGE_FTP = Yes
+PERMIT_DISTFILES_CDROM = Yes
+PERMIT_DISTFILES_FTP = Yes
+
+post-install:
+	${INSTALL_DATA_DIR} ${PREFIX}/share/doc/rpm
+	@for d in CHANGES COPYING CREDITS ChangeLog GROUPS README ; do \
+		${INSTALL_DATA} ${WRKSRC}/$$d ${PREFIX}/share/doc/rpm/$$d ; \
+	done
+
+.include <bsd.port.mk>

--- a/misc/rpm/distinfo
+++ b/misc/rpm/distinfo
@@ -1,0 +1,5 @@
+MD5 (rpm-4.9.1.1.tar.bz2) = 3mTnQQchqo43etuEMM/J4g==
+RMD160 (rpm-4.9.1.1.tar.bz2) = w/Mhh5WEw9LJPEeDqgpT5ZIlU/M=
+SHA1 (rpm-4.9.1.1.tar.bz2) = ELrRCZEUSdwAdej2L5ssOyF1pn4=
+SHA256 (rpm-4.9.1.1.tar.bz2) = EjeaMLg2klMYLtKBzCNNPZTmdtZv8k6bJ3UQ1I0prhY=
+SIZE (rpm-4.9.1.1.tar.bz2) = 3498822

--- a/misc/rpm/patches/patch-Makefile_am
+++ b/misc/rpm/patches/patch-Makefile_am
@@ -1,0 +1,21 @@
+$OpenBSD$
+--- Makefile.am.orig	Wed Dec 22 06:17:20 2010
++++ Makefile.am	Tue Jun 28 12:58:13 2011
+@@ -217,14 +217,14 @@ EXTRA_DIST += rpmpopt.in
+ 
+ usrsrcdir = $(prefix)/src
+ 
+-rpmvardir = $(localstatedir)/lib/rpm
++rpmvardir = $(localstatedir)/db/rpm
+ rpmvar_DATA =
+ 
+ install-exec-hook:
+ 	@rm -f $(DESTDIR)$(bindir)/rpmquery
+-	@LN_S@ ../../bin/rpm $(DESTDIR)$(bindir)/rpmquery
++	@LN_S@ rpm $(DESTDIR)$(bindir)/rpmquery
+ 	@rm -f $(DESTDIR)$(bindir)/rpmverify
+-	@LN_S@ ../../bin/rpm $(DESTDIR)$(bindir)/rpmverify
++	@LN_S@ rpm $(DESTDIR)$(bindir)/rpmverify
+ 
+ install-data-local:
+ 	@case "@host_os@" in \

--- a/misc/rpm/patches/patch-build_pack_c
+++ b/misc/rpm/patches/patch-build_pack_c
@@ -1,0 +1,11 @@
+$OpenBSD$
+--- build/pack.c.orig	Tue Feb 15 08:03:56 2011
++++ build/pack.c	Tue Jun 28 13:39:00 2011
+@@ -8,6 +8,7 @@
+ #include <errno.h>
+ #include <netdb.h>
+ #include <time.h>
++#include <sys/wait.h>
+ 
+ #include <rpm/rpmlib.h>			/* RPMSIGTAG*, rpmReadPackageFile */
+ #include <rpm/rpmts.h>

--- a/misc/rpm/patches/patch-configure_ac
+++ b/misc/rpm/patches/patch-configure_ac
@@ -1,0 +1,15 @@
+$OpenBSD$
+--- configure.ac.orig	Wed Mar  2 01:46:20 2011
++++ configure.ac	Sun Jun 26 18:49:05 2011
+@@ -530,9 +530,8 @@ AS_IF([test "$enable_python" = yes],[
+     CPPFLAGS="$save_CPPFLAGS"
+     save_LIBS="$LIBS"
+     AC_SEARCH_LIBS([Py_Main],[python${PYTHON_VERSION} python],[
+-      WITH_PYTHON_LIB="$ac_res"
+-    ],[AC_MSG_ERROR([missing python library])
+-    ])
++      WITH_PYTHON_LIB="-lutil -lm $ac_res"
++    ],[AC_MSG_ERROR([missing python library])],[-lutil -lm])
+     LIBS="$save_LIBS"
+   ])
+ ],[

--- a/misc/rpm/patches/patch-lib_backend_db3_c
+++ b/misc/rpm/patches/patch-lib_backend_db3_c
@@ -1,0 +1,20 @@
+$OpenBSD$
+--- lib/backend/db3.c.orig	Wed Mar  2 01:40:10 2011
++++ lib/backend/db3.c	Sun Jun 26 19:46:27 2011
+@@ -6,6 +6,7 @@ static int _debug = 1;	/* XXX if < 0 debugging, > 0 un
+ 
+ #include "system.h"
+ 
++#include <signal.h>
+ #include <errno.h>
+ #include <sys/wait.h>
+ 
+@@ -213,7 +214,7 @@ errxit:
+ 
+ void dbSetFSync(void *dbenv, int enable)
+ {
+-    db_env_set_func_fsync(enable ? fdatasync : fsync_disable);
++    db_env_set_func_fsync(enable ? fsync : fsync_disable);
+ }
+ 
+ int dbiSync(dbiIndex dbi, unsigned int flags)

--- a/misc/rpm/patches/patch-lib_rpmscript_c
+++ b/misc/rpm/patches/patch-lib_rpmscript_c
@@ -1,0 +1,11 @@
+$OpenBSD$
+--- lib/rpmscript.c.orig	Fri Jan 28 06:22:02 2011
++++ lib/rpmscript.c	Tue Jun 28 13:13:44 2011
+@@ -2,6 +2,7 @@
+ 
+ #include <errno.h>
+ #include <unistd.h>
++#include <sys/wait.h>
+ 
+ #define _RPMSQ_INTERNAL
+ #include <rpm/rpmsq.h>

--- a/misc/rpm/patches/patch-m4_gettext_m4
+++ b/misc/rpm/patches/patch-m4_gettext_m4
@@ -1,0 +1,11 @@
+$OpenBSD$
+--- m4/gettext.m4.orig	Fri Dec 10 05:47:14 2010
++++ m4/gettext.m4	Tue Jun 28 12:20:42 2011
+@@ -296,6 +296,7 @@ return * gettext ("")$gt_expression_test_code + _nl_ms
+     if test "$gt_use_preinstalled_gnugettext" = "yes"; then
+       if { eval "gt_val=\$$gt_func_gnugettext_libintl"; test "$gt_val" = "yes"; }; then
+         AC_MSG_CHECKING([how to link with libintl])
++        LIBINTL="-lintl $LIBICONV"
+         AC_MSG_RESULT([$LIBINTL])
+         AC_LIB_APPENDTOVAR([CPPFLAGS], [$INCINTL])
+       fi

--- a/misc/rpm/patches/patch-m4_iconv_m4
+++ b/misc/rpm/patches/patch-m4_iconv_m4
@@ -1,0 +1,11 @@
+$OpenBSD$
+--- m4/iconv.m4.orig	Fri Dec 10 05:47:14 2010
++++ m4/iconv.m4	Tue Jun 28 11:35:24 2011
+@@ -60,6 +60,7 @@ AC_DEFUN([AM_ICONV_LINK],
+   fi
+   if test "$am_cv_lib_iconv" = yes; then
+     AC_MSG_CHECKING([how to link with libiconv])
++    LIBICONV="-liconv"
+     AC_MSG_RESULT([$LIBICONV])
+   else
+     dnl If $LIBICONV didn't lead to a usable library, we don't need $INCICONV

--- a/misc/rpm/patches/patch-macros_in
+++ b/misc/rpm/patches/patch-macros_in
@@ -1,0 +1,12 @@
+$OpenBSD$
+--- macros.in.orig	Mon Jan  3 08:57:41 2011
++++ macros.in	Tue Jun 28 12:59:34 2011
+@@ -158,7 +158,7 @@
+ %_bzip2bin		%{__bzip2}
+ 
+ #	The location of the rpm database file(s).
+-%_dbpath		%{_var}/lib/rpm
++%_dbpath		%{_var}/db/rpm
+ 
+ #	The location of the rpm database file(s) after "rpm --rebuilddb".
+ %_dbpath_rebuild	%{_dbpath}

--- a/misc/rpm/patches/patch-misc_fts_c
+++ b/misc/rpm/patches/patch-misc_fts_c
@@ -1,0 +1,28 @@
+$OpenBSD$
+--- misc/fts.c.orig	Fri Dec  3 07:11:57 2010
++++ misc/fts.c	Sun Jun 26 18:59:46 2011
+@@ -66,6 +66,7 @@ static char sccsid[] = "@(#)fts.c	8.6 (Berkeley) 8/14/
+ #include <string.h>
+ #include <errno.h>
+ #include "misc/fts.h"
++#   define __errno_location() (&errno)
+ #   define __set_errno(val) (*__errno_location ()) = (val)
+ #   define __open	open
+ #   define __close	close
+@@ -1111,14 +1112,14 @@ static int
+ fts_safe_changedir(FTS * sp, FTSENT * p, int fd, const char * path)
+ {
+ 	int ret, oerrno, newfd;
+-	struct stat64 sb;
++	struct stat sb;
+ 
+ 	newfd = fd;
+ 	if (ISSET(FTS_NOCHDIR))
+ 		return (0);
+ 	if (fd < 0 && (newfd = __open(path, O_RDONLY, 0)) < 0)
+ 		return (-1);
+-	if (__fxstat64(_STAT_VER, newfd, &sb)) {
++	if (fstat(newfd, &sb)) {
+ 		ret = -1;
+ 		goto bail;
+ 	}

--- a/misc/rpm/patches/patch-misc_fts_h
+++ b/misc/rpm/patches/patch-misc_fts_h
@@ -1,0 +1,12 @@
+$OpenBSD$
+--- misc/fts.h.orig	Fri Dec  3 07:11:57 2010
++++ misc/fts.h	Sun Jun 26 19:02:32 2011
+@@ -57,6 +57,8 @@
+ # define _D_EXACT_NAMLEN(d) ((d)->d_reclen)
+ #endif
+ 
++# define _D_EXACT_NAMLEN(d) ((d)->d_namlen)
++
+ #if defined(__APPLE__)
+ # define _D_EXACT_NAMLEN(d) (strlen((d)->d_name))
+ #endif

--- a/misc/rpm/patches/patch-misc_glob_c
+++ b/misc/rpm/patches/patch-misc_glob_c
@@ -1,0 +1,59 @@
+$OpenBSD$
+--- misc/glob.c.orig	Fri Dec  3 07:11:57 2010
++++ misc/glob.c	Tue Jun 28 12:55:31 2011
+@@ -101,7 +101,7 @@ next_brace_sub (const char *begin)
+   return cp;
+ }
+ 
+-static int __glob_pattern_p (const char *pattern, int quote);
++int glob_pattern_p (const char *pattern, int quote);
+ 
+ /* Do glob searching for PATTERN, placing results in PGLOB.
+    The bits defined above may be set in FLAGS.
+@@ -316,7 +316,7 @@ glob (const char *pattern, int flags,
+ #endif
+ 	  /* For now, disallow wildcards in the drive spec, to
+ 	     prevent infinite recursion in glob.  */
+-	  if (__glob_pattern_p (drive_spec, !(flags & GLOB_NOESCAPE)))
++	  if (glob_pattern_p (drive_spec, !(flags & GLOB_NOESCAPE)))
+ 	    return GLOB_NOMATCH;
+ 	  /* If this is "d:pattern", we need to copy `:' to DIRNAME
+ 	     as well.  If it's "d:/pattern", don't remove the slash
+@@ -588,7 +588,7 @@ glob (const char *pattern, int flags,
+       return GLOB_NOMATCH;
+     }
+ 
+-  if (__glob_pattern_p (dirname, !(flags & GLOB_NOESCAPE)))
++  if (glob_pattern_p (dirname, !(flags & GLOB_NOESCAPE)))
+     {
+       /* The directory name contains metacharacters, so we
+ 	 have to glob for the directory, and then glob for
+@@ -912,8 +912,8 @@ prefix_array (const char *dirname, char **array, size_
+ #if !defined _LIBC || !defined NO_GLOB_PATTERN_P
+ /* Return nonzero if PATTERN contains any metacharacters.
+    Metacharacters can be quoted with backslashes if QUOTE is nonzero.  */
+-static int
+-__glob_pattern_p (const char *pattern, int quote)
++int
++glob_pattern_p (const char *pattern, int quote)
+ {
+   register const char *p;
+   int open = 0;
+@@ -943,7 +943,7 @@ __glob_pattern_p (const char *pattern, int quote)
+   return 0;
+ }
+ # ifdef _LIBC
+-weak_alias (__glob_pattern_p, glob_pattern_p)
++weak_alias (glob_pattern_p, glob_pattern_p)
+ # endif
+ #endif
+ 
+@@ -968,7 +968,7 @@ glob_in_dir (const char *pattern, const char *director
+   int meta;
+   int save;
+ 
+-  meta = __glob_pattern_p (pattern, !(flags & GLOB_NOESCAPE));
++  meta = glob_pattern_p (pattern, !(flags & GLOB_NOESCAPE));
+   if (meta == 0)
+     {
+       if (flags & (GLOB_NOCHECK|GLOB_NOMAGIC))

--- a/misc/rpm/patches/patch-rpmio_rpmsq_c
+++ b/misc/rpm/patches/patch-rpmio_rpmsq_c
@@ -1,0 +1,134 @@
+$OpenBSD$
+--- rpmio/rpmsq.c.orig	Fri Dec  3 07:11:57 2010
++++ rpmio/rpmsq.c	Tue Jun 28 13:07:12 2011
+@@ -40,6 +40,38 @@ static struct rpmsqElem rpmsqRock;
+ 
+ static rpmsq rpmsqQueue = &rpmsqRock;
+ 
++static int xsighold(int sig) {
++    sigset_t mask;
++
++    if (sigemptyset(&mask) == -1) {
++        fprintf(stderr, "%s line %d: %s", __func__, __LINE__, strerror(errno));
++        abort();
++    }
++
++    if (sigaddset(&mask, SIGCHLD) == -1) {
++        fprintf(stderr, "%s line %d: %s", __func__, __LINE__, strerror(errno));
++        abort();
++    }
++
++    return sigsuspend(&mask);
++}
++
++static int xsigrelse(int sig) {
++    sigset_t mask;
++
++    if (sigemptyset(&mask) == -1) {
++        fprintf(stderr, "%s line %d: %s", __func__, __LINE__, strerror(errno));
++        abort();
++    }
++
++    if (sigaddset(&mask, SIGCHLD) == -1) {
++        fprintf(stderr, "%s line %d: %s", __func__, __LINE__, strerror(errno));
++        abort();
++    }
++
++    return sigprocmask(SIG_UNBLOCK, &mask, NULL);    
++}
++
+ /** \ingroup rpmsq
+  * Insert node into from queue.
+  * @param elem          node to link
+@@ -52,7 +84,7 @@ static int rpmsqInsert(void * elem, void * prev)
+     int ret = -1;
+ 
+     if (sq != NULL) {
+-	ret = sighold(SIGCHLD);
++	ret = xsighold(SIGCHLD);
+ 	if (ret == 0) {
+ 	    sq->child = 0;
+ 	    sq->reaped = 0;
+@@ -63,7 +95,7 @@ static int rpmsqInsert(void * elem, void * prev)
+ 	    sq->id = ME();
+ 	    ret = pthread_mutex_init(&sq->mutex, NULL);
+ 	    insque(elem, (prev != NULL ? prev : rpmsqQueue));
+-	    ret = sigrelse(SIGCHLD);
++	    ret = xsigrelse(SIGCHLD);
+ 	}
+     }
+     return ret;
+@@ -80,7 +112,7 @@ static int rpmsqRemove(void * elem)
+     int ret = -1;
+ 
+     if (elem != NULL) {
+-	ret = sighold (SIGCHLD);
++	ret = xsighold (SIGCHLD);
+ 	if (ret == 0) {
+ 	    remque(elem);
+ 	   
+@@ -92,7 +124,7 @@ static int rpmsqRemove(void * elem)
+ 	    if (sq->pipes[1])	ret = close(sq->pipes[1]);
+ 	    if (sq->pipes[0])	ret = close(sq->pipes[0]);
+ 	    sq->pipes[0] = sq->pipes[1] = -1;
+-	    ret = sigrelse(SIGCHLD);
++	    ret = xsigrelse(SIGCHLD);
+ 	}
+     }
+     return ret;
+@@ -249,7 +281,7 @@ pid_t rpmsqFork(rpmsq sq)
+ 
+     xx = pipe(sq->pipes);
+ 
+-    xx = sighold(SIGCHLD);
++    xx = xsighold(SIGCHLD);
+ 
+     /* 
+      * Initialize the cond var mutex.   We have to aquire the lock we 
+@@ -287,7 +319,7 @@ pid_t rpmsqFork(rpmsq sq)
+     }
+ 
+ out:
+-    xx = sigrelse(SIGCHLD);
++    xx = xsigrelse(SIGCHLD);
+     return sq->child;
+ }
+ 
+@@ -304,7 +336,7 @@ static int rpmsqWaitUnregister(rpmsq sq)
+     int xx;
+ 
+     /* Protect sq->reaped from handler changes. */
+-    ret = sighold(SIGCHLD);
++    ret = xsighold(SIGCHLD);
+ 
+     /* Start the child, linux often runs child before parent. */
+     if (sq->pipes[0] >= 0)
+@@ -320,9 +352,9 @@ static int rpmsqWaitUnregister(rpmsq sq)
+     while (ret == 0 && sq->reaped != sq->child) {
+ 	if (nothreads)
+ 	    /* Note that sigpause re-enables SIGCHLD. */
+-	    ret = sigpause(SIGCHLD);
++	    ret = xsighold(SIGCHLD);
+ 	else {
+-	    xx = sigrelse(SIGCHLD);
++	    xx = xsigrelse(SIGCHLD);
+ 	    
+ 	    /* 
+ 	     * We start before the fork with this mutex locked;
+@@ -330,14 +362,14 @@ static int rpmsqWaitUnregister(rpmsq sq)
+ 	     * So if we get the lock the child has been reaped.
+ 	     */
+ 	    ret = pthread_mutex_lock(&sq->mutex);
+-	    xx = sighold(SIGCHLD);
++	    xx = xsighold(SIGCHLD);
+ 	}
+     }
+ 
+     /* Accumulate stopwatch time spent waiting, potential performance gain. */
+     sq->ms_scriptlets += rpmswExit(&sq->op, -1)/1000;
+ 
+-    xx = sigrelse(SIGCHLD);
++    xx = xsigrelse(SIGCHLD);
+ 
+     /* Remove processed SIGCHLD item from queue. */
+     xx = rpmsqRemove(sq);

--- a/misc/rpm/pkg/DESCR
+++ b/misc/rpm/pkg/DESCR
@@ -1,0 +1,13 @@
+The RPM Package Manager (RPM) is a powerful command line driven
+package management system capable of installing, uninstalling,
+verifying, querying, and updating software packages. Each software
+package consists of an archive of files along with information about
+the package like its version, a description, etc.
+
+The purpose of having rpm available as an OpenBSD port is to make
+life easy for Linux developers who happen to be using an OpenBSD
+system and to make it easy to examine RPM packages from an OpenBSD
+system.  Do not consider rpm a replacement for the ports system.
+
+The package database is set to /var/db/rpm by default, to conform
+with hier(7).

--- a/misc/rpm/pkg/PFRAG.shared
+++ b/misc/rpm/pkg/PFRAG.shared
@@ -1,0 +1,5 @@
+@comment $OpenBSD$
+@lib lib/librpm.so.${LIBrpm_VERSION}
+@lib lib/librpmbuild.so.${LIBrpmbuild_VERSION}
+@lib lib/librpmio.so.${LIBrpmio_VERSION}
+@lib lib/librpmsign.so.${LIBrpmsign_VERSION}

--- a/misc/rpm/pkg/PLIST
+++ b/misc/rpm/pkg/PLIST
@@ -1,0 +1,211 @@
+@comment $OpenBSD$
+%%SHARED%%
+@conflict rpm2cpio-*
+bin/gendiff
+@bin bin/rpm
+@bin bin/rpm2cpio
+@bin bin/rpmbuild
+@bin bin/rpmdb
+@bin bin/rpmgraph
+@bin bin/rpmkeys
+bin/rpmquery
+@bin bin/rpmsign
+@bin bin/rpmspec
+bin/rpmverify
+include/rpm/
+include/rpm/argv.h
+include/rpm/header.h
+include/rpm/rpmbuild.h
+include/rpm/rpmcallback.h
+include/rpm/rpmcli.h
+include/rpm/rpmdb.h
+include/rpm/rpmds.h
+include/rpm/rpmfc.h
+include/rpm/rpmfi.h
+include/rpm/rpmfileutil.h
+include/rpm/rpmio.h
+include/rpm/rpmkeyring.h
+include/rpm/rpmlegacy.h
+include/rpm/rpmlib.h
+include/rpm/rpmlog.h
+include/rpm/rpmmacro.h
+include/rpm/rpmpgp.h
+include/rpm/rpmpol.h
+include/rpm/rpmprob.h
+include/rpm/rpmps.h
+include/rpm/rpmsign.h
+include/rpm/rpmspec.h
+include/rpm/rpmsq.h
+include/rpm/rpmstring.h
+include/rpm/rpmsw.h
+include/rpm/rpmtag.h
+include/rpm/rpmtd.h
+include/rpm/rpmte.h
+include/rpm/rpmts.h
+include/rpm/rpmtypes.h
+include/rpm/rpmurl.h
+include/rpm/rpmutil.h
+include/rpm/rpmvf.h
+lib/librpm.a
+lib/librpm.la
+lib/librpmbuild.a
+lib/librpmbuild.la
+lib/librpmio.a
+lib/librpmio.la
+lib/librpmsign.a
+lib/librpmsign.la
+lib/pkgconfig/rpm.pc
+lib/python${MODPY_VERSION}/site-packages/rpm/
+lib/python${MODPY_VERSION}/site-packages/rpm/__init__.py
+lib/python${MODPY_VERSION}/site-packages/rpm/_rpmbmodule.a
+lib/python${MODPY_VERSION}/site-packages/rpm/_rpmbmodule.la
+lib/python${MODPY_VERSION}/site-packages/rpm/_rpmbmodule.so
+lib/python${MODPY_VERSION}/site-packages/rpm/_rpmmodule.a
+lib/python${MODPY_VERSION}/site-packages/rpm/_rpmmodule.la
+lib/python${MODPY_VERSION}/site-packages/rpm/_rpmmodule.so
+lib/python${MODPY_VERSION}/site-packages/rpm/_rpmsmodule.a
+lib/python${MODPY_VERSION}/site-packages/rpm/_rpmsmodule.la
+lib/python${MODPY_VERSION}/site-packages/rpm/_rpmsmodule.so
+lib/python${MODPY_VERSION}/site-packages/rpm/transaction.py
+lib/rpm/
+lib/rpm-plugins/
+lib/rpm-plugins/exec.a
+lib/rpm-plugins/exec.la
+lib/rpm-plugins/exec.so
+lib/rpm-plugins/sepolicy.a
+lib/rpm-plugins/sepolicy.la
+lib/rpm-plugins/sepolicy.so
+lib/rpm/brp-compress
+lib/rpm/brp-java-gcjcompile
+lib/rpm/brp-python-bytecompile
+lib/rpm/brp-python-hardlink
+lib/rpm/brp-strip
+lib/rpm/brp-strip-comment-note
+lib/rpm/brp-strip-shared
+lib/rpm/brp-strip-static-archive
+lib/rpm/check-buildroot
+lib/rpm/check-files
+lib/rpm/check-prereqs
+lib/rpm/check-rpaths
+lib/rpm/check-rpaths-worker
+lib/rpm/config.guess
+lib/rpm/config.sub
+lib/rpm/desktop-file.prov
+lib/rpm/fileattrs/
+lib/rpm/fileattrs/desktop.attr
+lib/rpm/fileattrs/elf.attr
+lib/rpm/fileattrs/font.attr
+lib/rpm/fileattrs/libtool.attr
+lib/rpm/fileattrs/mono.attr
+lib/rpm/fileattrs/ocaml.attr
+lib/rpm/fileattrs/perl.attr
+lib/rpm/fileattrs/perllib.attr
+lib/rpm/fileattrs/pkgconfig.attr
+lib/rpm/fileattrs/python.attr
+lib/rpm/fileattrs/script.attr
+lib/rpm/find-lang.sh
+lib/rpm/find-provides
+lib/rpm/find-requires
+lib/rpm/fontconfig.prov
+@bin lib/rpm/javadeps
+lib/rpm/libtooldeps.sh
+lib/rpm/macros
+lib/rpm/macros.perl
+lib/rpm/macros.php
+lib/rpm/macros.python
+lib/rpm/mkinstalldirs
+lib/rpm/mono-find-provides
+lib/rpm/mono-find-requires
+lib/rpm/ocaml-find-provides.sh
+lib/rpm/ocaml-find-requires.sh
+lib/rpm/osgideps.pl
+lib/rpm/perl.prov
+lib/rpm/perl.req
+lib/rpm/perldeps.pl
+lib/rpm/pkgconfigdeps.sh
+lib/rpm/pythondeps.sh
+lib/rpm/rpm.daily
+lib/rpm/rpm.log
+lib/rpm/rpm2cpio.sh
+lib/rpm/rpmdb_loadcvt
+@bin lib/rpm/rpmdeps
+lib/rpm/rpmpopt-4.9.1.1
+lib/rpm/rpmrc
+lib/rpm/script.req
+lib/rpm/tcl.req
+lib/rpm/tgpg
+man/fr/
+man/fr/man8/
+@man man/fr/man8/rpm.8
+man/ja/
+man/ja/man8/
+@man man/ja/man8/rpm.8
+@man man/ja/man8/rpm2cpio.8
+@man man/ja/man8/rpmbuild.8
+@man man/ja/man8/rpmgraph.8
+man/ko/
+man/ko/man8/
+@man man/ko/man8/rpm.8
+@man man/ko/man8/rpm2cpio.8
+@man man/man1/gendiff.1
+@man man/man8/rpm.8
+@man man/man8/rpm2cpio.8
+@man man/man8/rpmbuild.8
+@man man/man8/rpmdb.8
+@man man/man8/rpmdeps.8
+@man man/man8/rpmgraph.8
+@man man/man8/rpmkeys.8
+@man man/man8/rpmsign.8
+@man man/man8/rpmspec.8
+man/pl/
+man/pl/man1/
+@man man/pl/man1/gendiff.1
+man/pl/man8/
+@man man/pl/man8/rpm.8
+@man man/pl/man8/rpm2cpio.8
+@man man/pl/man8/rpmbuild.8
+@man man/pl/man8/rpmdeps.8
+@man man/pl/man8/rpmgraph.8
+man/ru/
+man/ru/man8/
+@man man/ru/man8/rpm.8
+@man man/ru/man8/rpm2cpio.8
+man/sk/
+man/sk/man8/
+@man man/sk/man8/rpm.8
+share/doc/rpm/
+share/doc/rpm/CHANGES
+share/doc/rpm/COPYING
+share/doc/rpm/CREDITS
+share/doc/rpm/ChangeLog
+share/doc/rpm/GROUPS
+share/doc/rpm/README
+share/locale/ca/LC_MESSAGES/rpm.mo
+share/locale/cs/LC_MESSAGES/rpm.mo
+share/locale/da/LC_MESSAGES/rpm.mo
+share/locale/de/LC_MESSAGES/rpm.mo
+share/locale/es/LC_MESSAGES/rpm.mo
+share/locale/fi/LC_MESSAGES/rpm.mo
+share/locale/fr/LC_MESSAGES/rpm.mo
+share/locale/is/LC_MESSAGES/rpm.mo
+share/locale/it/LC_MESSAGES/rpm.mo
+share/locale/ja/LC_MESSAGES/rpm.mo
+share/locale/ko/LC_MESSAGES/rpm.mo
+share/locale/ms/
+share/locale/ms/LC_MESSAGES/
+share/locale/ms/LC_MESSAGES/rpm.mo
+share/locale/nb/LC_MESSAGES/rpm.mo
+share/locale/nl/LC_MESSAGES/rpm.mo
+share/locale/pl/LC_MESSAGES/rpm.mo
+share/locale/pt/LC_MESSAGES/rpm.mo
+share/locale/pt_BR/LC_MESSAGES/rpm.mo
+share/locale/ru/LC_MESSAGES/rpm.mo
+share/locale/sk/LC_MESSAGES/rpm.mo
+share/locale/sl/LC_MESSAGES/rpm.mo
+share/locale/sr/LC_MESSAGES/rpm.mo
+share/locale/sr@latin/
+share/locale/sr@latin/LC_MESSAGES/
+share/locale/sr@latin/LC_MESSAGES/rpm.mo
+share/locale/sv/LC_MESSAGES/rpm.mo
+share/locale/tr/LC_MESSAGES/rpm.mo
+share/locale/zh_TW/LC_MESSAGES/rpm.mo


### PR DESCRIPTION
rpm-4.9.1.1 adds a lot, but it's actually compatible with RPMs in the
wild now.  Marc Espie said he did not mind me becoming the maintainer
of misc/rpm as he does not regularly use it and I do.  I do not have
an openbsd.org account, so I've just put my personal address in there
for now.

It builds and packages cleanly for me on amd64 -current.  I removed
the pre-configure: target I had before and make use of the 'autoconf'
CONFIGURE_STYLE feature in the ports system.  Seems to do the trick.

Let me know if there's anything else you want me to do on this port.
