### PR TITLE
add net/stuntman

### DIFF
--- a/net/stuntman/Makefile
+++ b/net/stuntman/Makefile
@@ -1,0 +1,39 @@
+# $OpenBSD:
+
+COMMENT =	STUN server implementation RFCs 5389, 5769, and 5780
+
+VERSION =	1.1.1
+DISTVERSION =	1_1_1
+DISTNAME =	stunserver_${DISTVERSION}
+PKGNAME =	stuntman-${VERSION}
+CATEGORIES =	net
+EXTRACT_SUFX =	.tgz
+
+MAINTAINER =	Roman Kravchuk <kravchuk.kp@gmail.com>
+
+HOMEPAGE =	http://www.stunprotocol.org/
+
+MASTER_SITES = http://www.stunprotocol.org/
+
+# Apache 2.0 license
+PERMIT_PACKAGE_CDROM=	Yes
+PERMIT_PACKAGE_FTP=	Yes
+PERMIT_DISTFILES_CDROM=	Yes
+PERMIT_DISTFILES_FTP=	Yes
+
+WANTLIB += 		c crypto m pthread stdc++
+
+LIB_DEPENDS =		devel/boost
+
+MAKE_FLAGS =		BOOST_INCLUDE='-I/usr/local/include'
+
+USE_GMAKE =	Yes
+
+WRKDIST = ${WRKDIR}/stunserver
+
+do-install:
+	${INSTALL_PROGRAM} ${WRKSRC}/stunserver ${PREFIX}/sbin
+	${INSTALL_PROGRAM} ${WRKSRC}/stunclient ${PREFIX}/sbin
+	${INSTALL_PROGRAM} ${WRKSRC}/stuntestcode ${PREFIX}/sbin
+	
+.include <bsd.port.mk>

--- a/net/stuntman/distinfo
+++ b/net/stuntman/distinfo
@@ -1,0 +1,5 @@
+MD5 (stunserver_1_1_1.tgz) = VVNgFYCBbRok6gE/Cc76HA==
+RMD160 (stunserver_1_1_1.tgz) = ZDfqtWOFr9cGhmVAb7ubmPYDL9I=
+SHA1 (stunserver_1_1_1.tgz) = 4x12SKrBV5C5wYy45/i5K/xprj0=
+SHA256 (stunserver_1_1_1.tgz) = Q+DYvdHe31UlLxoGfOwaf1pzFcQridfLYGZDNJFDzb0=
+SIZE (stunserver_1_1_1.tgz) = 112975

--- a/net/stuntman/patches/patch-networkutils_recvfromex_cpp
+++ b/net/stuntman/patches/patch-networkutils_recvfromex_cpp
@@ -1,0 +1,12 @@
+$OpenBSD$
+--- networkutils/recvfromex.cpp.orig	Thu Apr 12 10:50:43 2012
++++ networkutils/recvfromex.cpp	Thu Apr 12 10:51:05 2012
+@@ -18,7 +18,7 @@
+ 
+ #include "commonincludes.h"
+ #include "socketaddress.h"
+-
++#include <sys/uio.h>
+ 
+ static void GetLocalPortNumberFromSocket(int sockfd, CSocketAddress* pAddr)
+ {

--- a/net/stuntman/pkg/DESCR
+++ b/net/stuntman/pkg/DESCR
@@ -1,0 +1,4 @@
+STUNTMAN is an open source, high performance STUN server, 
+implementation of the STUN protocol as specified in 
+RFCs 5389, 5769, and 5780. It also includes backwards 
+compatibility for RFC 3489

--- a/net/stuntman/pkg/PLIST
+++ b/net/stuntman/pkg/PLIST
@@ -1,0 +1,4 @@
+@comment $OpenBSD$
+@bin sbin/stunclient
+@bin sbin/stunserver
+@bin sbin/stuntestcode


### PR DESCRIPTION
Comment:
STUN server implementation RFCs 5389, 5769, and 5780

Description:
STUNTMAN is an open source, high performance STUN server,
implementation of the STUN protocol as specified in
RFCs 5389, 5769, and 5780. It also includes backwards
compatibility for RFC 3489
