### PR TITLE
Replace LLVM_PATH in CONFIGURE_ARGS

### DIFF
--- a/devel/include-what-you-use/Makefile
+++ b/devel/include-what-you-use/Makefile
@@ -1,9 +1,11 @@
 #	$OpenBSD$
 
-COMMENT=	tool to analyse #includes in C and C++ source files
+COMMENT=	tool to analyse \#includes in C and C++ source files
 CATEGORIES=	devel
 DISTNAME=	include-what-you-use-0.5.src
 PKGNAME=	include-what-you-use-0.5
+REVISION=	0
+
 HOMEPAGE=	http://include-what-you-use.org
 MASTER_SITES=	${HOMEPAGE}/downloads/
 WRKDIST=	${WRKDIR}/include-what-you-use
@@ -17,7 +19,7 @@ BUILD_DEPENDS=	devel/llvm
 MODULES=		devel/cmake gcc4 lang/python
 MODGCC4_LANGS =		c++
 MODGCC4_ARCHS =		*
-CONFIGURE_ARGS=		-DLLVM_PATH=${LOCALBASE}
+CONFIGURE_ARGS=		-DIWYU_LLVM_ROOT_PATH=${LOCALBASE}
 
 post-install:
 	@perl -pi -e 's,/usr/bin/env python,/usr/bin/env python${MODPY_VERSION},g' \


### PR DESCRIPTION
There's a build-time warning telling us that LLVM_PATH is deprecated
and that we should use IWYU_LLVM_ROOT_PATH.