### PR TITLE
Add cpath and rpath pledges when interfacing with the moc server only.

### DIFF
--- a/audio/moc/patches/patch-main_c
+++ b/audio/moc/patches/patch-main_c
@@ -47,7 +47,7 @@ $OpenBSD$
  
 -	if (!params.only_server && params.dont_run_iface)
 +	if (!params.only_server && params.dont_run_iface) {
-+		if (pledge("stdio unix", NULL) == -1)
++		if (pledge("cpath rpath stdio unix", NULL) == -1)
 +			fatal ("pledge() failed: %s", strerror(errno));
  		server_command (&params, args);
 -	else


### PR DESCRIPTION
Add a couple of additional pledges necessary for communicating with the moc server.