### PR TITLE
allow strife-ve to use system paths for data files

### DIFF
--- a/games/strife-ve/Makefile
+++ b/games/strife-ve/Makefile
@@ -30,8 +30,19 @@ NO_TEST =	Yes
 
 WRKSRC =	${WRKDIST}/${GH_PROJECT}-src
 
+# Fix up system-wide install paths
+post-extract:
+	@sed -i 's,/games/doom,/strife-ve,g' ${WRKSRC}/src/d_iwad.c
+	@sed -i 's,"movies/,"${TRUEPREFIX}/share/strife-ve/movies/,g' \
+		${WRKSRC}/src/strife/d_main.c
+
 # No upstream install target
 do-install:
 	${INSTALL_PROGRAM} ${WRKBUILD}/${GH_PROJECT} ${PREFIX}/bin
+	${INSTALL_DATA_DIR} ${PREFIX}/share/strife-ve
+	${INSTALL_DATA_DIR} ${PREFIX}/share/examples/strife-ve
+	${SUBST_CMD} -c -m ${SHAREMODE} -o ${SHAREOWN} -g ${SHAREGRP} \
+		${FILESDIR}/strife-music.cfg \
+		${PREFIX}/share/examples/strife-ve/strife-music.cfg
 
 .include <bsd.port.mk>

--- a/games/strife-ve/files/strife-music.cfg
+++ b/games/strife-ve/files/strife-music.cfg
@@ -1,0 +1,37 @@
+# Example Strife: Veteran Edition substitute MIDI file.
+
+# SHA1 hash                              = filename
+8ac2b2b47707f0fdf8f67496ba3e27ff3cf38efa = ${TRUEPREFIX}/share/strife-ve/music/D_LOGO.ogg
+62e1c58054a1f1bc39b20e39bdb3f932b663de03 = ${TRUEPREFIX}/share/strife-ve/music/D_ACTION.ogg
+12fa000f3fa1edac5c4f7ed5d152183ecf78e661 = ${TRUEPREFIX}/share/strife-ve/music/D_TAVERN.ogg
+695e56ab3251792d20e509bf4cb3e0b6932648ea = ${TRUEPREFIX}/share/strife-ve/music/D_DANGER.ogg
+96fe30e8712217b60dd7ef40e49783aae06f358c = ${TRUEPREFIX}/share/strife-ve/music/D_FAST.ogg
+ec8fa484c4e85adbf70060eea82668a4bdfb09a2 = ${TRUEPREFIX}/share/strife-ve/music/D_INTRO.ogg
+61345598a3de04aad5084c695521d46d17c7f94e = ${TRUEPREFIX}/share/strife-ve/music/D_DARKER.ogg
+52353e9a435b7b1cb2687de5dd315df372342337 = ${TRUEPREFIX}/share/strife-ve/music/D_STRIKE.ogg
+061164504907bffc9c2267a4f320e23d700f0b55 = ${TRUEPREFIX}/share/strife-ve/music/D_SLIDE.ogg
+3dbb4b703ce69aafcdd59d748fb5a33f1a6381f0 = ${TRUEPREFIX}/share/strife-ve/music/D_TRIBAL.ogg
+393773688eba050c3548498a2a8640cc7b495227 = ${TRUEPREFIX}/share/strife-ve/music/D_MARCH.ogg
+695e56ab3251792d20e509bf4cb3e0b6932648ea = ${TRUEPREFIX}/share/strife-ve/music/D_DANGER.ogg
+3cba3c627de065a667dd63da234c5a2055fb5ba8 = ${TRUEPREFIX}/share/strife-ve/music/D_MOOD.ogg
+b1f65a333e5c70255784d702c30f9fdfedecf10c = ${TRUEPREFIX}/share/strife-ve/music/D_CASTLE.ogg
+61345598a3de04aad5084c695521d46d17c7f94e = ${TRUEPREFIX}/share/strife-ve/music/D_DARKER.ogg
+62e1c58054a1f1bc39b20e39bdb3f932b663de03 = ${TRUEPREFIX}/share/strife-ve/music/D_ACTION.ogg
+e1455a83a04c9ac4a09f6a941dbaf85631c9c15c = ${TRUEPREFIX}/share/strife-ve/music/D_FIGHT.ogg
+17f822b7374b1f069b891d651288c758bbe77d7c = ${TRUEPREFIX}/share/strife-ve/music/D_SPENSE.ogg
+061164504907bffc9c2267a4f320e23d700f0b55 = ${TRUEPREFIX}/share/strife-ve/music/D_SLIDE.ogg
+52353e9a435b7b1cb2687de5dd315df372342337 = ${TRUEPREFIX}/share/strife-ve/music/D_STRIKE.ogg
+e66c5a1a7d05f021f4ae531bff95c34176e6b121 = ${TRUEPREFIX}/share/strife-ve/music/D_DARK.ogg
+1c92bd0625026af30dadeb2e30a68252cae324aa = ${TRUEPREFIX}/share/strife-ve/music/D_TECH.ogg
+061164504907bffc9c2267a4f320e23d700f0b55 = ${TRUEPREFIX}/share/strife-ve/music/D_SLIDE.ogg
+7ae280713d078de7933a998479000b0205f1793a = ${TRUEPREFIX}/share/strife-ve/music/D_DRONE.ogg
+4a664afd0d7eae79c97aaac42877e3f679618f8d = ${TRUEPREFIX}/share/strife-ve/music/D_PANTHR.ogg
+4a7d62beeac5601ccf218bccfefee42b6028051e = ${TRUEPREFIX}/share/strife-ve/music/D_SAD.ogg
+e60e109779400f2855d72a77d37ffc547edb4729 = ${TRUEPREFIX}/share/strife-ve/music/D_INSTRY.ogg
+1c92bd0625026af30dadeb2e30a68252cae324aa = ${TRUEPREFIX}/share/strife-ve/music/D_TECH.ogg
+62e1c58054a1f1bc39b20e39bdb3f932b663de03 = ${TRUEPREFIX}/share/strife-ve/music/D_ACTION.ogg
+e60e109779400f2855d72a77d37ffc547edb4729 = ${TRUEPREFIX}/share/strife-ve/music/D_INSTRY.ogg
+7ae280713d078de7933a998479000b0205f1793a = ${TRUEPREFIX}/share/strife-ve/music/D_DRONE.ogg
+e1455a83a04c9ac4a09f6a941dbaf85631c9c15c = ${TRUEPREFIX}/share/strife-ve/music/D_FIGHT.ogg
+b7d36878faeb291d6df52b153da2dffdfe6999dc = ${TRUEPREFIX}/share/strife-ve/music/D_HAPPY.ogg
+ff4a342c8c5ec51b06c3e16247fb16d0f02d8b84 = ${TRUEPREFIX}/share/strife-ve/music/D_END.ogg

--- a/games/strife-ve/pkg/PLIST
+++ b/games/strife-ve/pkg/PLIST
@@ -1,3 +1,6 @@
 @comment $OpenBSD$
 @bin bin/strife-ve
 share/doc/pkg-readmes/${FULLPKGNAME}
+share/examples/strife-ve/
+share/examples/strife-ve/strife-music.cfg
+share/strife-ve/

--- a/games/strife-ve/pkg/README
+++ b/games/strife-ve/pkg/README
@@ -13,9 +13,14 @@ GOG.com release of the game.
 You must extract the files from
 setup_the_original_strife_-_veteran_edition_gog-2a_(12083)_(g).exe using
 using the innoextract package. The files will be in a directory named
-app. You must keep this directory, though it can be renamed and moved to
-a location of your choosing, and you can delete everything else that is
-extracted from the exe, such as the tmp directory.
+app.  Copy the game data files:
 
-strife-ve should be launched from the app directory for full video and
-music support.
+# cp {strife1,voices,SVE}.wad ${PREFIX}/share/strife-ve/
+
+Optionally, you may copy the movies/ and music/ directories to the same
+location for intro trailers and enhanced game music.  Copy the example
+configuration to enable the music substitutions:
+
+$ mkdir -p ~/.local/share/strife-ve/music
+$ cp ${PREFIX}/share/examples/strife-ve/strife-music.cfg \
+	~/.local/share/strife-ve/music/


### PR DESCRIPTION
modifies installation instructions to suit, includes example
strife-music.cfg and copy commands to use.

Tests good on current amd64 here, thanks for putting the port together!