### PR TITLE
editors/py-neovim: include comments for the unobvious bits

### DIFF
--- a/editors/py-neovim/Makefile
+++ b/editors/py-neovim/Makefile
@@ -31,6 +31,8 @@ TEST_DEPENDS =		${RUN_DEPENDS} \
 
 WRKDIST =		${WRKDIR}/neovim-${MODPY_EGG_VERSION}
 
+# You may need to increase the number of open file descriptors for the tests to
+# pass.
 do-test:
 	cd ${WRKSRC} && ${LOCALBASE}/bin/py.test${MODPY_BIN_SUFFIX}
 

--- a/editors/py-neovim/patches/patch-test_conftest_py
+++ b/editors/py-neovim/patches/patch-test_conftest_py
@@ -1,5 +1,10 @@
 $OpenBSD$
 
+Although this file is present in the upstream source tree, it was not
+included when the release tarball was created.  This file is needed to
+run unit tests and was copied from the release tag matching this
+version.
+
 Index: test/conftest.py
 --- test/conftest.py.orig
 +++ test/conftest.py


### PR DESCRIPTION
Add comments for why the patch is needed and make a note about needing
to increase file descriptor limit for unit tests.