### PR TITLE
- Arduino Duemilanove was using the same UNO/Nano conf, so doesn't du…

### DIFF
--- a/devel/arduino/files/Makefile
+++ b/devel/arduino/files/Makefile
@@ -34,24 +34,32 @@
 
 PORT = /dev/cuaU0
 
-# Arduino Uno/Nano
-ARDUINO_ARCH=avr
-UPLOAD_RATE = 57600
+# Arduino UNO
+ARDUINO_ARCH = avr
+UPLOAD_RATE = 115200
 AVRDUDE_PROGRAMMER = arduino
 MCU = atmega328p
 F_CPU = 16000000
 VARIANT = standard
 
-## Arduino Duemilanove
-#ARDUINO_ARCH=avr
+# Arduino Duemilanove/Nano/Pro Mini
+#ARDUINO_ARCH = avr
 #UPLOAD_RATE = 57600
 #AVRDUDE_PROGRAMMER = arduino
 #MCU = atmega328p
 #F_CPU = 16000000
 #VARIANT = standard
 
-## Arduino Mega
-#ARDUINO_ARCH=avr
+## Arduino Mega 2560
+#ARDUINO_ARCH = avr
+#UPLOAD_RATE = 115200
+#AVRDUDE_PROGRAMMER = stk500v2
+#MCU = atmega2560
+#F_CPU = 16000000
+#VARIANT = mega
+
+## Arduino Mega 1280
+#ARDUINO_ARCH = avr
 #UPLOAD_RATE = 57600
 #AVRDUDE_PROGRAMMER = arduino
 #MCU = atmega1280
@@ -59,7 +67,7 @@ VARIANT = standard
 #VARIANT = mega
 
 ## older Arduino
-#ARDUINO_ARCH=avr
+#ARDUINO_ARCH = avr
 #UPLOAD_RATE = 19200
 #AVRDUDE_PROGRAMMER = stk500
 #MCU = atmega328p
@@ -156,6 +164,9 @@ AVRDUDE_WRITE_FLASH = -U flash:w:applet/$(TARGET).hex
 AVRDUDE_CONF = /etc/avrdude.conf
 AVRDUDE_FLAGS = -V -F -C $(AVRDUDE_CONF) -p $(MCU) -P $(AVRDUDE_PORT) \
 -c $(AVRDUDE_PROGRAMMER) -b $(UPLOAD_RATE)
+.ifdef $(VARIANT) == mega
+AVRDUDE_FLAGS += -D
+.endif
 
 # Program settings
 CC = $(AVR_TOOLS_PATH)/avr-gcc


### PR DESCRIPTION
I tried to contact Bryan Conway (who managed to upgrade from 1.0.2 to 1.8.5) with the following e-mail (but got no response), so I'm sending a pull request.

The e-mail:

I've been testing the devel/arduino upgrade to 1.8.5 from openbsd-wip. I could
succesfully generate working firmware for the following boards:

- Duemilanove
- Pro Mini
- Mega 2560 (clone)
- UNO (clone)

However, I would like to suggest some changes to the Makefile template (not the
ports Makefile). The changes:

- Arduino UNO/Nano and Arduino Duemilanove are set with the same
  configuration. There would be no need to duplicate, but Arduino UNO works at
  115200 bps. My hardware is a clone, and I couldn't upload with 57600 bps as
  suggested on template, and some googling suggests it's indeed 115200 bps
  (someone with the original Italian version could test it better);

- specify Arduino Mega 2560 and Arduino 1280 separately;

- add a -D flag when uploading to Mega. To upload to Mega, avrdude man page                                                                                                                                           
  suggests that auto erase is not used for ATxmega, but when uploading to it, an                                                                                                                                      
  auto erase is attempted and it fails. So explicitly disabling auto erase is
  needed;

```
avrdude: Device signature = 0x1e9801                                        
avrdude: NOTE: FLASH memory has been specified, an erase cycle will be performed
         To disable this feature, specify the -D option.
avrdude: erasing chip                                               
avrdude: stk500v2_command(): command failed

avrdude done.  Thank you.                    

*** Error 255 in /home/dbolgheroni/proj/openbsd-can/can-tx-18 (Makefile:237 'upload')
```

Thank you.