### PR TITLE
Add tags support.

### DIFF
--- a/devel/arduino/files/Makefile
+++ b/devel/arduino/files/Makefile
@@ -198,12 +198,10 @@ mkdirs:
 
 tags:
 	@if [ ! -x ${LOCALBASE}/bin/ectags ]; then \
-		echo "devel/ectags required. Install it with pkg_add(1)."; \
+		echo "devel/universal-ctags required. Install it with pkg_add(1)."; \
 	else \
-		FTAGGED=$$(find ${LOCALBASE}/share/arduino \
-			-name '*.h' -o -name '*.c' -o -name '*.cpp'; \
-			find /usr/local/avr/include -name '*.h'); \
-		ectags --format=1 $${FTAGGED}; \
+		uctags -R --format=1 --languages=C,C++ \
+			${LOCALBASE}/share/arduino /usr/local/avr/include; \
 	fi
 
 # Here is the "preprocessing".

--- a/devel/arduino/files/Makefile
+++ b/devel/arduino/files/Makefile
@@ -196,6 +196,16 @@ mkdirs:
 		${LNDIR} ${LOCALBASE}/share/arduino ${ARDUINO}; \
 	fi
 
+tags:
+	@if [ ! -x ${LOCALBASE}/bin/ectags ]; then \
+		echo "devel/ectags required. Install it with pkg_add(1)."; \
+	else \
+		FTAGGED=$$(find ${LOCALBASE}/share/arduino \
+			-name '*.h' -o -name '*.c' -o -name '*.cpp'; \
+			find /usr/local/avr/include -name '*.h'); \
+		ectags --format=1 $${FTAGGED}; \
+	fi
+
 # Here is the "preprocessing".
 # It creates a .cpp file based with the same name as the .ino file.
 # On top of the new .cpp file comes the Arduino.h header.


### PR DESCRIPTION
The ctags from base doesn't support C++, and Arduino is basically C++. Do a check for devel/ectags from ports and print a message suggesting to install it.