### PR TITLE
libotf 0.9.16

### DIFF
--- a/misc/libotf/Makefile
+++ b/misc/libotf/Makefile
@@ -15,7 +15,7 @@ MAINTAINER =		Eric Brown <brown@fastmail.com>
 # LGPLv2+
 PERMIT_PACKAGE_CDROM =	Yes
 
-WANTLIB = c freetype z
+WANTLIB += c freetype z
 
 MASTER_SITES =		http://download.savannah.gnu.org/releases/m17n/
 

--- a/misc/libotf/Makefile
+++ b/misc/libotf/Makefile
@@ -1,0 +1,26 @@
+# $OpenBSD: Makefile,v 1.00 2018/12/06 15:00:06 ecb Exp $
+
+COMMENT = 		library for handling OpenType Fonts
+
+DISTNAME =		libotf-0.9.16
+
+SHARED_LIBS =		otf	1.0
+
+CATEGORIES = 		misc
+
+HOMEPAGE =		https://www.nongnu.org/m17n/
+
+MAINTAINER =		Eric Brown <brown@fastmail.com>
+
+# LGPLv2+
+PERMIT_PACKAGE_CDROM =	Yes
+
+WANTLIB =	 	freetype
+
+MASTER_SITES =		http://download.savannah.gnu.org/releases/m17n/
+
+CONFIGURE_STYLE=        gnu
+
+NO_TEST =		Yes
+
+.include <bsd.port.mk>

--- a/misc/libotf/Makefile
+++ b/misc/libotf/Makefile
@@ -15,7 +15,7 @@ MAINTAINER =		Eric Brown <brown@fastmail.com>
 # LGPLv2+
 PERMIT_PACKAGE_CDROM =	Yes
 
-WANTLIB =	 	freetype
+WANTLIB = c freetype z
 
 MASTER_SITES =		http://download.savannah.gnu.org/releases/m17n/
 

--- a/misc/libotf/distinfo
+++ b/misc/libotf/distinfo
@@ -1,0 +1,2 @@
+SHA256 (libotf-0.9.16.tar.gz) = aNsMo82i1GpmOpLsJubrWtw5LqUZG82nQmjwrvp4Bms=
+SIZE (libotf-0.9.16.tar.gz) = 423979

--- a/misc/libotf/pkg/DESCR
+++ b/misc/libotf/pkg/DESCR
@@ -1,0 +1,10 @@
+The library "libotf" provides the following facilites.
+
+     Read Open Type Layout Tables from OTF file.  Currently these
+     tables are supported; head, name, cmap, GDEF, GSUB, and GPOS.
+
+     Convert a Unicode character sequence to a glyph code sequence by
+     using the above tables.
+
+The combination of libotf and the FreeType library (Ver.2) realizes
+CTL (complex text layout) by OpenType fonts.

--- a/misc/libotf/pkg/PLIST
+++ b/misc/libotf/pkg/PLIST
@@ -1,0 +1,10 @@
+@comment $OpenBSD: PLIST,v$
+bin/libotf-config
+@bin bin/otfdump
+@bin bin/otflist
+@bin bin/otftobdf
+include/otf.h
+lib/libotf.a
+lib/libotf.la
+@lib lib/libotf.so.${LIBotf_VERSION}
+lib/pkgconfig/libotf.pc


### PR DESCRIPTION
libotf is a library for working with OpenType fonts.