### PR TITLE
bring uwsgi up to date

### DIFF
--- a/www/uwsgi/Makefile
+++ b/www/uwsgi/Makefile
@@ -1,44 +1,42 @@
 # $OpenBSD$
 
-COMMENT-main=	web service hosting stack
-COMMENT-python=	python plugin for uWSGI web service hosting stack
-COMMENT-lua=	lua plugin for uWSGI web service hosting stack
+COMMENT-main=		web service hosting stack
+COMMENT-python3=	python plugin for uWSGI web service hosting stack
+COMMENT-lua=		lua plugin for uWSGI web service hosting stack
 
-V=		2.0.12
-DISTNAME=	uwsgi-$V
-PKGNAME-main=	uwsgi-$V
-PKGNAME-python=	uwsgi-plugin-python2.7-$V
-PKGNAME-lua=	uwsgi-plugin-lua-$V
+V=			2.0.18
+DISTNAME=		uwsgi-$V
+PKGNAME-main=		uwsgi-$V
+PKGNAME-python3=	uwsgi-plugin-python3-$V
+PKGNAME-lua=		uwsgi-plugin-lua-$V
 
-MULTI_PACKAGES=	-main -python -lua
+MULTI_PACKAGES=	-main -python3 -lua
 
-CATEGORIES=	www
+CATEGORIES=		www
 
-HOMEPAGE=	http://uwsgi-docs.readthedocs.org/en/latest/
+HOMEPAGE=		http://uwsgi-docs.readthedocs.org/en/latest/
 
 # GPLv2
-PERMIT_PACKAGE_CDROM=	Yes
+PERMIT_PACKAGE=		Yes
 
-WANTLIB-main += ${MODLIBICONV_WANTLIB} c crypto execinfo jansson kvm m
+WANTLIB-main += iconv c crypto execinfo jansson kvm m
 WANTLIB-main += pcre perl pthread ssl util xml2 z
 
-WANTLIB-python=	${MODPY_WANTLIB} m pthread util
-WANTLIB-lua=	${MODLUA_WANTLIB} m
+WANTLIB-python3=	${MODPY_WANTLIB} m pthread util
+WANTLIB-lua=		${MODLUA_WANTLIB} m
 
-MASTER_SITES=	http://projects.unbit.it/downloads/
+MASTER_SITES=		http://projects.unbit.it/downloads/
 
-MODULES=	converters/libiconv \
-		lang/lua \
-		lang/python
-LIB_DEPENDS-main= ${MODLIBICONV_LIB_DEPENDS} \
-		devel/jansson \
-		devel/libexecinfo \
-		devel/pcre \
-		textproc/libxml
-LIB_DEPENDS-python= ${MODPY_LIB_DEPENDS}
-LIB_DEPENDS-lua= ${MODLUA_LIB_DEPENDS}
-RUN_DEPENDS=	www/uwsgi
-RUN_DEPENDS-main= ${MODLIBICONV_RUN_DEPENDS}
+MODULES=		lang/lua \
+			lang/python
+MODPY_VERSION =		${MODPY_DEFAULT_VERSION_3}
+LIB_DEPENDS-main=	devel/jansson \
+			devel/libexecinfo \
+			devel/pcre \
+			textproc/libxml
+LIB_DEPENDS-python3= 	${MODPY_LIB_DEPENDS}
+LIB_DEPENDS-lua= 	${MODLUA_LIB_DEPENDS}
+RUN_DEPENDS=		www/uwsgi
 
 MAKE_JOBS?=	1
 MAKE_FLAGS=	PYTHON="${MODPY_BIN}" \

--- a/www/uwsgi/distinfo
+++ b/www/uwsgi/distinfo
@@ -1,2 +1,2 @@
-SHA256 (uwsgi-2.0.12.tar.gz) = MGtR25dkjW0ju36s125aQTQ0V18iDawd4jHIwm0z5Ak=
-SIZE (uwsgi-2.0.12.tar.gz) = 784048
+SHA256 (uwsgi-2.0.18.tar.gz) = SXKsU4gA+y1CECf0m0oYabZgSIOVB8zwqi/aeS2Z9YM=
+SIZE (uwsgi-2.0.18.tar.gz) = 801555

--- a/www/uwsgi/pkg/DESCR-python3
+++ b/www/uwsgi/pkg/DESCR-python3
@@ -1,0 +1,1 @@
+This package contains the Python 2.7 plugin for uWSGI.

--- a/www/uwsgi/pkg/PLIST-lua
+++ b/www/uwsgi/pkg/PLIST-lua
@@ -1,2 +1,2 @@
-@comment $OpenBSD$
-lib/uwsgi/lua_plugin.so
+@comment $OpenBSD: PLIST-lua,v$
+@so lib/uwsgi/lua_plugin.so

--- a/www/uwsgi/pkg/PLIST-main
+++ b/www/uwsgi/pkg/PLIST-main
@@ -1,7 +1,9 @@
-@comment $OpenBSD$
-lib/uwsgi/
-lib/uwsgi/cache_plugin.so
-lib/uwsgi/ping_plugin.so
-lib/uwsgi/psgi_plugin.so
-@bin sbin/uwsgi
+@comment $OpenBSD: PLIST-main,v$
+@newgroup _uwsgi:849
+@newuser _uwsgi:849:_uwsgi:daemon:UWSGI user:/nonexistent:/sbin/nologin
 @rcscript ${RCDIR}/uwsgi
+@so lib/uwsgi/cache_plugin.so
+@so lib/uwsgi/ping_plugin.so
+@so lib/uwsgi/psgi_plugin.so
+@bin sbin/uwsgi
+share/doc/pkg-readmes/${PKGSTEM}

--- a/www/uwsgi/pkg/PLIST-python3
+++ b/www/uwsgi/pkg/PLIST-python3
@@ -1,0 +1,4 @@
+@comment $OpenBSD: PLIST-python3,v$
+lib/python${MODPY_VERSION}/site-packages/${MODPY_PYCACHE}uwsgidecorators.${MODPY_PYC_MAGIC_TAG}pyc
+lib/python${MODPY_VERSION}/site-packages/uwsgidecorators.py
+@so lib/uwsgi/python_plugin.so

--- a/www/uwsgi/pkg/README-main
+++ b/www/uwsgi/pkg/README-main
@@ -1,0 +1,9 @@
+uwsgi on OpenBSD
+================
+
+As noted in the docs[1], you may need to raise the number of
+semaphores. To do so, add something like the following to
+/etc/sysctl.conf
+
+kern.seminfo.semmni=25
+

--- a/www/uwsgi/pkg/uwsgi.rc
+++ b/www/uwsgi/pkg/uwsgi.rc
@@ -1,0 +1,14 @@
+#!/bin/ksh
+#
+# $OpenBSD: rc.template,v 1.12 2018/01/11 19:30:18 rpe Exp $
+
+daemon="${TRUEPREFIX}/sbin/uwsgi"
+daemon_user="_uwsgi"
+
+. /etc/rc.d/rc.subr
+
+pexp="${daemon}${daemon_flags:+ ${daemon_flags}}"
+rc_reload=NO
+
+rc_cmd $1
+


### PR DESCRIPTION
After botching the last merge request, here's a new one

- Included RC file
- Update to 2.0.18
- Creates `_uwsgi` user
- Switches to Python3 plugin
- Add note from the docs about increasing the number of semaphores