### PR TITLE
obs-studio: fix build and finding path to obs-ffmpeg-mux

### DIFF
--- a/multimedia/obs-studio/Makefile
+++ b/multimedia/obs-studio/Makefile
@@ -5,6 +5,7 @@ COMMENT=	software for live-streaming and screen recording
 GH_ACCOUNT=	jp9000
 GH_PROJECT=	obs-studio
 GH_TAGNAME=	23.2.1
+REVISION=	0
 
 SHARED_LIBS=	obs			0.0 \
 		obs-frontend-api	0.0 \

--- a/multimedia/obs-studio/patches/patch-libobs_util_platform-nix_c
+++ b/multimedia/obs-studio/patches/patch-libobs_util_platform-nix_c
@@ -1,0 +1,31 @@
+$OpenBSD$
+
+Index: libobs/util/platform-nix.c
+--- libobs/util/platform-nix.c.orig
++++ libobs/util/platform-nix.c
+@@ -272,11 +272,15 @@ char *os_get_program_data_path_ptr(const char *name)
+ 
+ char *os_get_executable_path_ptr(const char *name)
+ {
+-	char exe[PATH_MAX];
+-	ssize_t count = readlink("/proc/self/exe", exe, PATH_MAX);
+ 	const char *path_out = NULL;
+ 	struct dstr path;
+ 
++#ifdef __OpenBSD__
++	path_out = "/usr/local/bin";
++#else
++	char exe[PATH_MAX];
++	ssize_t count = readlink("/proc/self/exe", exe, PATH_MAX);
++
+ 	if (count == -1) {
+ 		return NULL;
+ 	}
+@@ -285,6 +289,7 @@ char *os_get_executable_path_ptr(const char *name)
+ 	if (!path_out) {
+ 		return NULL;
+ 	}
++#endif
+ 
+ 	dstr_init_copy(&path, path_out);
+ 	dstr_cat(&path, "/");

--- a/multimedia/obs-studio/patches/patch-plugins_obs-outputs_librtmp_rtmp_c
+++ b/multimedia/obs-studio/patches/patch-plugins_obs-outputs_librtmp_rtmp_c
@@ -1,0 +1,14 @@
+$OpenBSD$
+
+Index: plugins/obs-outputs/librtmp/rtmp.c
+--- plugins/obs-outputs/librtmp/rtmp.c.orig
++++ plugins/obs-outputs/librtmp/rtmp.c
+@@ -890,7 +890,7 @@ add_addr_info(struct sockaddr_storage *service, sockle
+         // since we're handling multiple addresses internally, fake the correct error response
+ #ifdef _WIN32
+         *socket_error = WSANO_DATA;
+-#elif __FreeBSD__
++#elif __FreeBSD__ || __OpenBSD__
+         *socket_error = ENOATTR;
+ #else
+         *socket_error = ENODATA;


### PR DESCRIPTION
Hardcoding /usr/local/bin is not good, but right above os_get_executable_path_ptr are a bunch of functions where /usr/local is already hard-coded, so what's one more.

Still looking into why the audio is stuttering when recording, but otherwise video and window capturing work fine.