### PR TITLE
godot4: disable hardcoded optimization flags

### DIFF
--- a/games/godot4/patches/patch-SConstruct
+++ b/games/godot4/patches/patch-SConstruct
@@ -1,0 +1,15 @@
+disable hardcoded compiler/linker flags.  We handle stripping and debug
+(-g), as well as optimizations (-On), by ourselves.
+
+Index: SConstruct
+--- SConstruct.orig
++++ SConstruct
+@@ -581,7 +581,7 @@ if selected_platform in platform_list:
+             env.Append(LINKFLAGS=["/OPT:REF"])
+         elif env["optimize"] == "debug" or env["optimize"] == "none":
+             env.Append(CCFLAGS=["/Od"])
+-    else:
++    elif False: # disable -g/-O/-s flags; we handle them ourselves
+         if env["debug_symbols"]:
+             # Adding dwarf-4 explicitly makes stacktraces work with clang builds,
+             # otherwise addr2line doesn't understand them

--- a/games/godot4/patches/patch-methods_py
+++ b/games/godot4/patches/patch-methods_py
@@ -1,0 +1,14 @@
+drop hardcoded -O3
+
+Index: methods.py
+--- methods.py.orig
++++ methods.py
+@@ -140,8 +140,6 @@ def force_optimization_on_debug(self):
+         self["CFLAGS"] = [x for x in self["CFLAGS"] if not x.startswith("/O")]
+         self["CXXFLAGS"] = [x for x in self["CXXFLAGS"] if not x.startswith("/O")]
+         self.AppendUnique(CCFLAGS=["/O2"])
+-    else:
+-        self.AppendUnique(CCFLAGS=["-O3"])
+ 
+ 
+ def add_module_version_string(self, s):


### PR DESCRIPTION
@rfht this should remove the hardcoded -O, -s and -g flags.  I'd still like to sneak in one more patch (add -I for miniupnpc instead of patching the sources), but after that I consider this ready to hit ports@? :-)

(needs a bump to the just-released 4.1.3 before though)