### PR TITLE
update games/serioussam

### DIFF
--- a/games/serioussam/Makefile
+++ b/games/serioussam/Makefile
@@ -1,6 +1,6 @@
 COMMENT =	open source version of the classic Serious Sam game
 
-V=		1.10.6c
+V=		1.10.6d
 
 DIST_TUPLE =	github tx00100xt SeriousSamClassic ${V} .
 PKGNAME =	serioussam-${V}

--- a/games/serioussam/distinfo
+++ b/games/serioussam/distinfo
@@ -1,2 +1,2 @@
-SHA256 (tx00100xt-SeriousSamClassic-1.10.6c.tar.gz) = M2KX/TKzkrZlYaBmlmciirY+5a9UDd4RsXnv8N2M7yA=
-SIZE (tx00100xt-SeriousSamClassic-1.10.6c.tar.gz) = 28936901
+SHA256 (tx00100xt-SeriousSamClassic-1.10.6d.tar.gz) = JtIoA2Bo37lm7MOYaBnj4X25OihElwJBbK7oUmx5XSs=
+SIZE (tx00100xt-SeriousSamClassic-1.10.6d.tar.gz) = 28948549

--- a/games/serioussam/patches/patch-SamTFE_Sources_Engine_Engine_cpp
+++ b/games/serioussam/patches/patch-SamTFE_Sources_Engine_Engine_cpp
@@ -1,0 +1,25 @@
+Index: SamTFE/Sources/Engine/Engine.cpp
+--- SamTFE/Sources/Engine/Engine.cpp.orig
++++ SamTFE/Sources/Engine/Engine.cpp
+@@ -740,20 +740,9 @@
+   // Path vars
+   sys_iGameBits  = (int)(CHAR_BIT * sizeof(void *));
+   CPrintF(TRANSV("Running %d-bit version\n"), sys_iGameBits);
++  sys_iSysPath = 1; // using system path
+ 
+ #ifdef PLATFORM_UNIX
+-#if defined(__OpenBSD__) || defined(__FreeBSD__)
+-  int _isystempath = strncmp((const char *)strExePath, (const char *) "/usr/local/bin/", (size_t) 15 );
+-#elif defined(__NetBSD__)
+-  int _isystempath = strncmp((const char *)strExePath, (const char *) "/usr/pkg/bin/", (size_t) 13 );
+-#else
+-  int _isystempath = strncmp((const char *)strExePath, (const char *) "/usr/bin/", (size_t) 9 );
+-#endif
+-  if( _isystempath == 0 ) {
+-       sys_iSysPath = 1; // using system path
+-  } else {
+-       sys_iSysPath = 0; // using standarted path
+-  }
+ 
+   // get library path for mods
+   _fnmModLibPath = "";

--- a/games/serioussam/patches/patch-SamTSE_Sources_Engine_Engine_cpp
+++ b/games/serioussam/patches/patch-SamTSE_Sources_Engine_Engine_cpp
@@ -1,0 +1,25 @@
+Index: SamTSE/Sources/Engine/Engine.cpp
+--- SamTSE/Sources/Engine/Engine.cpp.orig
++++ SamTSE/Sources/Engine/Engine.cpp
+@@ -740,20 +740,9 @@
+   // Path vars
+   sys_iGameBits  = (int)(CHAR_BIT * sizeof(void *));
+   CPrintF(TRANSV("Running %d-bit version\n"), sys_iGameBits);
++  sys_iSysPath = 1; // using system path
+ 
+ #ifdef PLATFORM_UNIX
+-#if defined(__OpenBSD__) || defined(__FreeBSD__)
+-  int _isystempath = strncmp((const char *)strExePath, (const char *) "/usr/local/bin/", (size_t) 15 );
+-#elif defined(__NetBSD__)
+-  int _isystempath = strncmp((const char *)strExePath, (const char *) "/usr/pkg/bin/", (size_t) 13 );
+-#else
+-  int _isystempath = strncmp((const char *)strExePath, (const char *) "/usr/bin/", (size_t) 9 );
+-#endif
+-  if( _isystempath == 0 ) {
+-       sys_iSysPath = 1; // using system path
+-  } else {
+-       sys_iSysPath = 0; // using standarted path
+-  }
+ 
+   // get library path for mods
+   _fnmModLibPath = "";


### PR DESCRIPTION
Bump to version 1.10.6d.

Fix broken texture effects.
Texture effects were broken when ported to Linux in 2016. https://github.com/icculus/Serious-Engine/commit/24cb244d4399845aa22cb4d8bf1e25760ae66a11
Version tagged 1.10.6d includes a fix for texture effects.
**Before fix:**
![before-fix](https://github.com/jasperla/openbsd-wip/assets/105300480/eb2564e9-6408-40d8-a835-16e7bfc6283e)
**After fix:**
![after-fix](https://github.com/jasperla/openbsd-wip/assets/105300480/08ad662e-2950-4897-bb10-89919f61c569)

Fix start mods from menu. 
Added patches fix errors when starting mod from the game menu for OpenBSD.

[Send to ports 2024-01-20](https://marc.info/?l=openbsd-ports&m=170575879322041)