### PR TITLE
gurk-rs: Fix sed in-place editing error.

### DIFF
--- a/net/gurk-rs/Makefile
+++ b/net/gurk-rs/Makefile
@@ -32,7 +32,8 @@ SUBST_VARS =	LOCALBASE
 # 		< ${FILESDIR}/notification.rs.patch
 
 post-configure:
-	sed -i '/opt-level/s,2,0,' ${WRKDIR}/.cargo/config
+	mv ${WRKDIR}/.cargo/config ${WRKDIR}/.cargo/config.orig
+	sed '/opt-level/s,2,0,' < ${WRKDIR}/.cargo/config.orig > ${WRKDIR}/.cargo/config
 	cat ${FILESDIR}/config >> ${WRKDIR}/.cargo/config
 
 do-install:


### PR DESCRIPTION
Without this change, make (specifically, `make FETCH_PACKAGES=-Dsnap MAKE_JOBS=3 PORTSDIR_PATH=/usr/ports:/usr/ports/openbsd-wip`) fails with:

```
[modcargo] Generating metadata for zvariant_derive-3.15.2
[modcargo] Generating metadata for zvariant_utils-1.0.1
===>  Generating configure for gurk-rs-0.4.3
===>  Configuring for gurk-rs-0.4.3
sed -i '/opt-level/s,2,0,' /home/pobj/gurk-rs-0.4.3/.cargo/config
sed: /home/pobj/gurk-rs-0.4.3/.cargo/config: in-place editing only works for regular files
*** Error 1 in . (Makefile:35 'post-configure')
*** Error 2 in . (/usr/ports/infrastructure/mk/bsd.port.mk:3044 '/home/pobj/gurk-rs-0.4.3/.co
nfigure_done': @cd /usr/ports/openbsd-wip/net/g...)
*** Error 2 in /usr/ports/openbsd-wip/net/gurk-rs (/usr/ports/infrastructure/mk/bsd.port.mk:2
704 'all': @lock=gurk-rs-0.4.3;  export _LOCKS_...)
exit: 2 angel gurk-rs $ grep -R opt-level
Makefile:       sed -i '/opt-level/s,2,0,' ${WRKDIR}/.cargo/config
```

Not sure why it works for other(s) but not me. My ports tree is at commit fd2b2c6a on the git mirror.

@c0dev0id 