### PR TITLE
net/microsocks: new port of 1.0.5 version

### DIFF
--- a/net/microsocks/Makefile
+++ b/net/microsocks/Makefile
@@ -1,0 +1,17 @@
+COMMENT =		tiny SOCKS5 server with very moderate resource usage
+V =			1.0.5
+PKGNAME =		microsocks-${V}
+CATEGORIES =		net
+MAINTAINER =		Viacheslav Chimishuk <vchimishuk@yandex.ru>
+HOMEPAGE =		https://github.com/rofl0r/microsocks
+GH_ACCOUNT =		rofl0r
+GH_PROJECT =		microsocks
+GH_TAGNAME =		v${V}
+PERMIT_PACKAGE =	Yes
+COMPILER =		base-clang ports-gcc base-gcc
+
+do-install:
+	${INSTALL_PROGRAM} ${WRKSRC}/microsocks ${PREFIX}/sbin
+	${INSTALL_MAN} ${WRKSRC}/microsocks.1 ${PREFIX}/man/man1
+
+.include <bsd.port.mk>

--- a/net/microsocks/distinfo
+++ b/net/microsocks/distinfo
@@ -1,0 +1,2 @@
+SHA256 (microsocks-1.0.5.tar.gz) = k50YUaGKTAPzzFyS/3pQ6vBF2ngUdktMueJpIdsVq8g=
+SIZE (microsocks-1.0.5.tar.gz) = 10413

--- a/net/microsocks/patches/patch-microsocks_1
+++ b/net/microsocks/patches/patch-microsocks_1
@@ -1,0 +1,100 @@
+Index: microsocks.1
+--- microsocks.1.orig
++++ microsocks.1
+@@ -0,0 +1,96 @@
++.Dd February 11, 2025
++.Dt MICROSOCKS 1
++.Os
++.Sh NAME
++.Nm microsocks
++.Nd tiny SOCKS5 server with very moderate resource usage
++.Sh SYNOPSIS
++.Bk -words
++.Bl -tag -width microsocks
++.It Nm
++.Op Fl 1q
++.Op Fl b Ar ip
++.Op Fl i Ar addr
++.Op Fl P Ar pass
++.Op Fl p Ar port
++.Op Fl u Ar user
++.Op Fl w Ar ips
++.Oc
++.El
++.Ek
++.Sh DESCRIPTION
++.Nm microsocks
++is a multithreaded, tiny, portable SOCKS5 server with very moderate resource
++usage that you can run on your remote boxes to tunnel connections through them,
++if for some reason SSH doesn't cut it for you.
++It is very lightweight, and very light on resources too: for every client, a
++thread with a low stack size is spawned. the main process basically doesn't
++consume any resources at all. It is also designed to be robust: it handles
++resource exhaustion gracefully by simply denying new connections, instead of
++calling
++.Xr abort 3
++as most other programs do these days.
++Another plus is ease-of-use: no config file necessary, everything can be done
++from the command line and doesn't even need any parameters for quick setup.
++.Sh OPTIONS
++The following options are supported by
++.Nm :
++.Bl -tag -width indent
++.It Fl 1
++Activates auth_once mode: once a specific IP address authorized successfully
++with user:password pair, it is added to a whitelist and may use the proxy
++without authorization. This is handy for programs like Firefox that don't
++support user:password authorization. For it to work you'd basically make one
++connection with another program that supports it, and then you can use Firefox
++too. This option requires options
++.Fl u
++and
++.Fl P
++also to be specified.
++.It Fl b Ar ip
++Specifies IP address outgoing connections are bound to.
++.It Fl i Ar addr
++Specifies local address to listen connections on. Host name or IP address can be
++supplied. Default to
++.Cm 0.0.0.0 .
++.It Fl P
++Specifies authorization password. This option requires
++.Fl u
++also to be specified.
++.It Fl p
++TCP port to listen to. Default to
++.Cm 1080 .
++.It Fl q
++Quiet mode: suppress logging messages.
++.It Fl u
++Specifies authorization username value. This option requires
++.Fl P
++also to be specified.
++.It Fl w
++A comma-separated whitelist of IP addresses, that may use the proxy without
++authentication. e.g.
++.Cm -w 127.0.0.1,192.168.1.1.1,::1
++or just
++.Cm -w 10.0.0.1 .
++To allow access ONLY to those IPs, choose an impossible to guess user:password
++combination.
++.El
++.Sh EXAMPLES
++Require authentication for all except two specified hosts.
++.Pp
++.Dl $ microsocks -w 192.168.1.100,192.168.1.101 -u user -P secret
++.Pp
++Listen on port 8080 and use 46.62.90.74 as a source IP for external connections.
++.Pp
++.Dl $ microsocks -i 0.0.0.0 -b 46.62.90.74 -p 8080
++.Pp
++Connect to
++.Lk https://freebsd.org
++using
++.Cm curl
++command through the running
++.Nm .
++.Pp
++.Dl $ curl --socks5 user:password@127.0.0.1:1080 https://freebsd.org
++.Sh AUTHORS
++.An rofl0r

--- a/net/microsocks/patches/patch-sockssrv_c
+++ b/net/microsocks/patches/patch-sockssrv_c
@@ -1,0 +1,13 @@
+Index: sockssrv.c
+--- sockssrv.c.orig
++++ sockssrv.c
+@@ -59,6 +59,9 @@
+ #elif defined(__GLIBC__) || defined(__FreeBSD__) || defined(__sun__)
+ #undef THREAD_STACK_SIZE
+ #define THREAD_STACK_SIZE 32*1024
++#elif defined(__OpenBSD__) && defined(__clang__)
++#undef THREAD_STACK_SIZE
++#define THREAD_STACK_SIZE 32*1024
+ #endif
+ 
+ static int quiet;

--- a/net/microsocks/pkg/DESCR
+++ b/net/microsocks/pkg/DESCR
@@ -1,0 +1,4 @@
+microsocks is a tiny SOCKS5 server with very moderate resource usage
+
+microsocks is configured using command-line options. Use rcctl(8)
+to modify execution flags if needed.

--- a/net/microsocks/pkg/PLIST
+++ b/net/microsocks/pkg/PLIST
@@ -1,0 +1,3 @@
+@rcscript ${RCDIR}/microsocks
+@man man/man1/microsocks.1
+@bin sbin/microsocks

--- a/net/microsocks/pkg/microsocks.rc
+++ b/net/microsocks/pkg/microsocks.rc
@@ -1,0 +1,11 @@
+#!/bin/ksh
+
+daemon="${TRUEPREFIX}/sbin/microsocks"
+daemon_flags="-q -i 127.0.0.1"
+
+. /etc/rc.d/rc.subr
+
+rc_reload=NO
+rc_bg=YES
+
+rc_cmd $1


### PR DESCRIPTION
Very simple, lightweight and easy to use SOCKS5 proxy. 

https://github.com/rofl0r/microsocks