### PR TITLE
math/pc: import

### DIFF
--- a/math/pc/Makefile
+++ b/math/pc/Makefile
@@ -1,0 +1,23 @@
+V =		0.6
+COMMENT =	programmer's calculator
+DISTNAME =	pc-${V}
+CATEGORIES =	math
+
+HOMEPAGE =	https://git.sr.ht/~ft/pc
+MAINTAINER =	Saeed Mahjoob <saeed@cloud9p.org>
+
+# MIT
+PERMIT_PACKAGE =	Yes
+
+WANTLIB += c m
+
+SITES =		https://git.sr.ht/~ft/pc/archive/
+
+DISTFILES =	pc-{}${V}${EXTRACT_SUFX}
+NO_TEST =	Yes
+
+do-install:
+	${INSTALL_PROGRAM} ${WRKDIST}/pc ${PREFIX}/bin
+	${INSTALL_DATA} ${WRKDIST}/pc.1 ${PREFIX}/man/man1
+
+.include <bsd.port.mk>

--- a/math/pc/distinfo
+++ b/math/pc/distinfo
@@ -1,0 +1,2 @@
+SHA256 (pc-0.6.tar.gz) = MGNtzwZpDVSDOJ5TdZrA6fpvwd5E3P54EZtpiwuVnZA=
+SIZE (pc-0.6.tar.gz) = 40470

--- a/math/pc/pkg/DESCR
+++ b/math/pc/pkg/DESCR
@@ -1,0 +1,3 @@
+Pc is an arbitrary precision integer calculator with a special emphasis
+on supporting two's complement bit operations and working with different
+number bases.

--- a/math/pc/pkg/PLIST
+++ b/math/pc/pkg/PLIST
@@ -1,0 +1,3 @@
+@pkgpath math/pc
+@bin bin/pc
+@man man/man1/pc.1


### PR DESCRIPTION
Hi. this PR adds math/pc.

which is a calculator from plan 9 operating system,
simaliar to bc, and better suited for interactive use.

it's my first port for OpenBSD, so lmk if there are 
rough edges and room for improvments. :-)