### PR TITLE
security/veracrypt: update to 1.26.29

### DIFF
--- a/security/veracrypt/Makefile
+++ b/security/veracrypt/Makefile
@@ -1,0 +1,67 @@
+BROKEN-sparc64=	relocation truncated to fit: R_SPARC_GOT13
+
+COMMENT=		free open source disk encryption software
+
+V=			1.26.29
+DISTNAME=		VeraCrypt_${V}_Source
+PKGNAME=		veracrypt-${V}
+CATEGORIES=		security
+HOMEPAGE=		https://www.veracrypt.fr/
+
+MAINTAINER=		Noah Axon <ax0n@h-i-r.net>
+
+# Apache2
+PERMIT_PACKAGE=	yes
+
+SITES=			https://github.com/veracrypt/VeraCrypt/releases/download/VeraCrypt_${V}/
+EXTRACT_SUFX=		.tar.bz2
+FIX_EXTRACT_PERMISSIONS=Yes
+
+# C++11
+COMPILER=		base-clang ports-gcc
+
+CXXFLAGS_base-clang =	-std=c++14
+
+WANTLIB += ${COMPILER_LIBCXX} c m fuse wx_baseu-3.2 wx_gtk3u_core-3.2
+
+BUILD_DEPENDS=		devel/yasm
+
+LIB_DEPENDS=		x11/wxWidgets
+
+RUN_DEPENDS=		devel/desktop-file-utils \
+			security/sudo \
+			sysutils/exfat-fuse
+
+WRKDIST=		${WRKDIR}/src
+USE_GMAKE=		Yes
+ALL_TARGET=
+MAKE_FLAGS=		VERBOSE=1 \
+			NOTEST=1 \
+			CC="${CC}" \
+			CXX="${CXX}" \
+			PORT_CFLAGS="${CFLAGS}" \
+			PORT_CXXFLAGS="${CXXFLAGS}"
+MAKE_ENV+=		SOURCE_DATE_EPOCH=0
+
+NO_TEST=		Yes
+
+.if ${MACHINE_ARCH:Mi386}
+MAKE_ENV+=		LFLAGS=-Wl,-z,notext
+.endif
+
+pre-configure:
+	${SUBST_CMD} ${WRKSRC}/Setup/FreeBSD/veracrypt.desktop
+
+do-install:
+	${INSTALL_PROGRAM} ${WRKSRC}/Main/veracrypt ${PREFIX}/bin
+	${INSTALL_DATA_DIR} ${PREFIX}/share/applications
+	${INSTALL_DATA} ${WRKSRC}/Setup/FreeBSD/veracrypt.desktop \
+		${PREFIX}/share/applications
+	${INSTALL_DATA_DIR} ${PREFIX}/share/pixmaps/
+	${INSTALL_DATA} ${WRKSRC}/Resources/Icons/VeraCrypt-256x256.xpm \
+		${PREFIX}/share/pixmaps/veracrypt.xpm
+	${INSTALL_DATA_DIR} ${PREFIX}/share/icons/hicolor/scalable/apps/
+	${INSTALL_DATA} ${WRKSRC}/Resources/Icons/VeraCrypt.svg \
+		${PREFIX}/share/icons/hicolor/scalable/apps/veracrypt.svg
+
+.include <bsd.port.mk>

--- a/security/veracrypt/TODO
+++ b/security/veracrypt/TODO
@@ -1,0 +1,4 @@
+- Test on architectures beyond amd64 (sparc64 is marked BROKEN upstream)
+- Consider whether exfat-fuse should be a soft dependency
+- Upstream the OpenBSD patches (GetHostDevices, mount.exfat direct call)
+- Send diff to ports@ and CC maintainer (main@tietoturvamies.fi)

--- a/security/veracrypt/UPDATE
+++ b/security/veracrypt/UPDATE
@@ -1,0 +1,32 @@
+Update security/veracrypt to 1.26.29
+
+This is an update to the existing port in the main tree (1.25.9),
+
+Changes from upstream 1.26.29:
+- Argon2id KDF support
+- Reproducible build infrastructure
+- OpenBSD File::Length() fix (proper per-partition size via DIOCGDINFO)
+- OpenBSD doas/FUSE fixes
+- vnconfig -c flag removal (adapted to current OpenBSD)
+- wxWidgets Forms.cpp regenerated (fixes wxALIGN+wxEXPAND conflicts)
+
+Patches carried (5):
+- patch-Makefile: don't hardcode -O2, inject port CFLAGS/CXXFLAGS,
+  make LFLAGS conditionally assignable
+- patch-Core_Unix_OpenBSD_CoreOpenBSD_cpp: fix bare throw; in
+  AttachFileToLoopDevice, implement GetHostDevices() via sysctl
+  hw.disknames, mount fallback chain (msdos -> exfat-fuse -> ffs)
+- patch-Core_VolumeCreator_h: OpenBSD filesystem formatters
+- patch-Main_Forms_VolumeFormatOptionsWizardPage_cpp: filesystem
+  type UI choices for OpenBSD
+- patch-Setup_FreeBSD_veracrypt_desktop: fix Exec path
+
+Patches dropped (fixed upstream):
+- patch-Platform_Unix_File_cpp (device size calculation)
+- patch-Main_Forms_Forms_cpp (wxWidgets alignment)
+
+New dependency: sysutils/exfat-fuse (RUN_DEPENDS) for exFAT volume
+mounting. Calls mount.exfat directly since OpenBSD mount -t expects
+mount_exfat (underscore) but exfat-fuse uses dot convention.
+
+Tested on amd64/OpenBSD-CURRENT (June 12, 2026 Snapshot)

--- a/security/veracrypt/distinfo
+++ b/security/veracrypt/distinfo
@@ -1,0 +1,2 @@
+SHA256 (VeraCrypt_1.26.29_Source.tar.bz2) = YIJnMeKYK0vSMeOTDoWkQ5EWljhnGhsgDFGPjItGyyo=
+SIZE (VeraCrypt_1.26.29_Source.tar.bz2) = 36302144

--- a/security/veracrypt/patches/patch-Core_Unix_OpenBSD_CoreOpenBSD_cpp
+++ b/security/veracrypt/patches/patch-Core_Unix_OpenBSD_CoreOpenBSD_cpp
@@ -1,0 +1,180 @@
+Fix bare throw; in AttachFileToLoopDevice (readOnly not supported on OpenBSD).
+Implement GetHostDevices() using sysctl hw.disknames.
+Try msdos then exfat-fuse when auto-detecting filesystem type on mount.
+Call mount.exfat directly since OpenBSD mount -t expects mount_exfat (underscore)
+but exfat-fuse installs mount.exfat (dot convention).
+
+Index: Core/Unix/OpenBSD/CoreOpenBSD.cpp
+--- Core/Unix/OpenBSD/CoreOpenBSD.cpp.orig
++++ Core/Unix/OpenBSD/CoreOpenBSD.cpp
+@@ -15,11 +15,15 @@
+
+ #include <fstream>
+ #include <iostream>
++#include <sstream>
++#include <vector>
++#include <fcntl.h>
+ #include <stdio.h>
+ #include <unistd.h>
+ #include <sys/param.h>
+ #include <sys/ucred.h>
+ #include <sys/mount.h>
++#include <sys/sysctl.h>
+ #include <sys/wait.h>
+ #include "CoreOpenBSD.h"
+ #include "Core/Unix/CoreServiceProxy.h"
+@@ -40,7 +44,7 @@
+
+ 		if (readOnly)
+ 		{
+-			throw;
++			// vnconfig on OpenBSD does not support read-only mode
+ 		}
+
+ 		// find an available vnd
+@@ -102,10 +106,84 @@
+ 		}
+ 	}
+
+-	// not sure what this is used for
+ 	HostDeviceList CoreOpenBSD::GetHostDevices (bool pathListOnly) const
+ 	{
+-		throw;
++		HostDeviceList devices;
++
++		// Get disk names via sysctl hw.disknames
++		int mib[2] = { CTL_HW, HW_DISKNAMES };
++		size_t len = 0;
++		if (sysctl(mib, 2, NULL, &len, NULL, 0) == -1 || len == 0)
++			return devices;
++
++		vector<char> buf(len + 1, 0);
++		if (sysctl(mib, 2, buf.data(), &len, NULL, 0) == -1)
++			return devices;
++
++		// Parse "sd0:uid,sd1:uid,cd0:" format
++		string diskStr(buf.data());
++		stringstream ss(diskStr);
++		string entry;
++
++		while (getline(ss, entry, ','))
++		{
++			string diskName = entry.substr(0, entry.find(':'));
++			if (diskName.empty())
++				continue;
++
++			// Only enumerate sd and wd disk devices
++			if (diskName.compare(0, 2, "sd") != 0
++			    && diskName.compare(0, 2, "wd") != 0)
++				continue;
++
++			// Whole disk: 'c' partition on OpenBSD
++			string devPath = "/dev/" + diskName + "c";
++
++			if (!FilesystemPath(devPath).IsBlockDevice()
++			    && !FilesystemPath(devPath).IsCharacterDevice())
++				continue;
++
++			make_shared_auto(HostDevice, device);
++			device->Path = devPath;
++
++			if (!pathListOnly)
++			{
++				try { device->Size = GetDeviceSize(device->Path); }
++				catch (...) { device->Size = 0; }
++				device->MountPoint = GetDeviceMountPoint(device->Path);
++				device->SystemNumber = 0;
++			}
++
++			devices.push_back(device);
++
++			// Enumerate partitions a-p, skipping c (whole disk)
++			for (char p = 'a'; p <= 'p'; p++)
++			{
++				if (p == 'c')
++					continue;
++
++				string partPath = "/dev/" + diskName + string(1, p);
++
++				if (!FilesystemPath(partPath).IsBlockDevice()
++				    && !FilesystemPath(partPath).IsCharacterDevice())
++					continue;
++
++				make_shared_auto(HostDevice, partition);
++				partition->Path = partPath;
++
++				if (!pathListOnly)
++				{
++					try { partition->Size = GetDeviceSize(partition->Path); }
++					catch (...) { partition->Size = 0; }
++					partition->MountPoint = GetDeviceMountPoint(partition->Path);
++					partition->SystemNumber = 0;
++				}
++
++				device->Partitions.push_back(partition);
++			}
++		}
++
++		return devices;
+ 	}
+
+ 	MountedFilesystemList CoreOpenBSD::GetMountedFilesystems (const DevicePath &devicePath, const DirectoryPath &mountPoint) const
+@@ -145,18 +223,51 @@
+ 	{
+ 		(void) internalMountOnly;
+
+-		try
++		if (!filesystemType.empty())
+ 		{
+-			// Try to mount FAT by default as mount is unable to probe filesystem type on BSD
+-			CoreUnix::MountFilesystem (devicePath, mountPoint, filesystemType.empty() ? "msdos" : filesystemType, readOnly, systemMountOptions);
++			CoreUnix::MountFilesystem (devicePath, mountPoint, filesystemType, readOnly, systemMountOptions);
++			return;
+ 		}
+-		catch (ExecutedProcessFailed&)
++
++		// OpenBSD mount cannot auto-detect filesystem type.
++		// Try common types in order: msdos (FAT), then exfat, then
++		// fall back to unspecified (which tries ffs).
++		try
+ 		{
+-			if (!filesystemType.empty())
+-				throw;
++			CoreUnix::MountFilesystem (devicePath, mountPoint, "msdos", readOnly, systemMountOptions);
++			return;
++		}
++		catch (ExecutedProcessFailed&) { }
+
+-			CoreUnix::MountFilesystem (devicePath, mountPoint, filesystemType, readOnly, systemMountOptions);
++		// Try exfat-fuse directly (mount.exfat uses dot convention,
++		// not mount_exfat underscore convention expected by mount -t)
++		try
++		{
++			list <string> exfatArgs;
++			string options;
++			if (readOnly)
++				options = "ro";
++			if (!systemMountOptions.empty())
++			{
++				if (!options.empty())
++					options += ",";
++				options += systemMountOptions;
++			}
++			if (!options.empty())
++			{
++				exfatArgs.push_back ("-o");
++				exfatArgs.push_back (options);
++			}
++			exfatArgs.push_back ("--");
++			exfatArgs.push_back (devicePath);
++			exfatArgs.push_back (mountPoint);
++			Process::Execute ("mount.exfat", exfatArgs);
++			return;
+ 		}
++		catch (...) { }
++
++		// Last resort: let mount guess (typically ffs)
++		CoreUnix::MountFilesystem (devicePath, mountPoint, "", readOnly, systemMountOptions);
+ 	}
+
+ #ifdef TC_OPENBSD

--- a/security/veracrypt/patches/patch-Core_VolumeCreator_h
+++ b/security/veracrypt/patches/patch-Core_VolumeCreator_h
@@ -1,0 +1,17 @@
+Add OpenBSD filesystem formatter mappings:
+- newfs_ext2fs for ext2 (base system)
+- mkfs.exfat for exFAT (from exfat-fuse package)
+
+Index: Core/VolumeCreator.h
+--- Core/VolumeCreator.h.orig
++++ Core/VolumeCreator.h
+@@ -88,6 +88,9 @@
+ 				case VolumeCreationOptions::FilesystemType::MacOsExt:	return "newfs_hfs";
+ 				case VolumeCreationOptions::FilesystemType::exFAT:		return "newfs_exfat";
+ 				case VolumeCreationOptions::FilesystemType::APFS:		return "newfs_apfs";
++	#elif defined (TC_OPENBSD)
++				case VolumeCreationOptions::FilesystemType::Ext2:		return "newfs_ext2fs";
++				case VolumeCreationOptions::FilesystemType::exFAT:		return "mkfs.exfat";
+ 	#elif defined (TC_FREEBSD) || defined (TC_SOLARIS)
+ 				case VolumeCreationOptions::FilesystemType::UFS:		return "newfs" ;
+ 	#endif

--- a/security/veracrypt/patches/patch-Main_Forms_VolumeFormatOptionsWizardPage_cpp
+++ b/security/veracrypt/patches/patch-Main_Forms_VolumeFormatOptionsWizardPage_cpp
@@ -1,0 +1,17 @@
+Add filesystem format options for OpenBSD: Ext2 and exFAT.
+
+Index: Main/Forms/VolumeFormatOptionsWizardPage.cpp
+--- Main/Forms/VolumeFormatOptionsWizardPage.cpp.orig
++++ Main/Forms/VolumeFormatOptionsWizardPage.cpp
+@@ -50,6 +50,11 @@
+ 		FilesystemTypeChoice->Append (L"exFAT",				(void *) VolumeCreationOptions::FilesystemType::exFAT);
+ 		if (wxPlatformInfo::Get().CheckOSVersion (10, 13))
+ 			FilesystemTypeChoice->Append (L"APFS",			(void *) VolumeCreationOptions::FilesystemType::APFS);
++#elif defined (TC_OPENBSD)
++		if (VolumeCreationOptions::FilesystemType::IsFsFormatterPresent (VolumeCreationOptions::FilesystemType::Ext2))
++			FilesystemTypeChoice->Append (L"Linux Ext2",		(void *) VolumeCreationOptions::FilesystemType::Ext2);
++		if (VolumeCreationOptions::FilesystemType::IsFsFormatterPresent (VolumeCreationOptions::FilesystemType::exFAT))
++			FilesystemTypeChoice->Append (L"exFAT",				(void *) VolumeCreationOptions::FilesystemType::exFAT);
+ #elif defined (TC_FREEBSD) || defined (TC_SOLARIS)
+ 		FilesystemTypeChoice->Append (L"UFS",				(void *) VolumeCreationOptions::FilesystemType::UFS);
+ #endif

--- a/security/veracrypt/patches/patch-Makefile
+++ b/security/veracrypt/patches/patch-Makefile
@@ -1,0 +1,36 @@
+- don't hardcode -O2
+- inject port infrastructure's cflags/cxxflags
+- make LFLAGS conditionally assignable
+
+Index: Makefile
+--- Makefile.orig	Mon Jun 22 17:58:16 2026
++++ Makefile	Mon Jun 22 17:58:22 2026
+@@ -50,7 +50,7 @@
+ export CXXFLAGS := -Wall -Wno-unused-parameter
+ C_CXX_FLAGS := -MMD -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_LARGE_FILES -I$(BASE_DIR) -I$(BASE_DIR)/Crypto -DARGON2_NO_THREADS -I$(BASE_DIR)/Crypto/Argon2/include
+ export ASFLAGS := -D __GNUC__ -D __YASM__
+-export LFLAGS :=
++export LFLAGS ?=
+ 
+ export PKG_CONFIG ?= pkg-config
+ export PKG_CONFIG_PATH ?= /usr/local/lib/pkgconfig
+@@ -111,7 +111,7 @@
+ 
+ ifeq "$(TC_BUILD_CONFIG)" "Release"
+ 
+-	C_CXX_FLAGS += -O2 -fno-strict-aliasing  # Do not enable strict aliasing
++	C_CXX_FLAGS += -fno-strict-aliasing  # Do not enable strict aliasing
+ 	export WX_BUILD_DIR ?= $(BASE_DIR)/wxrelease
+ 	WX_CONFIGURE_FLAGS += --disable-debug_flag --disable-debug_gdb --disable-debug_info
+ 
+@@ -585,8 +585,8 @@
+ 
+ #------ Common configuration ------
+ 
+-CFLAGS := $(C_CXX_FLAGS) $(CFLAGS) $(TC_EXTRA_CFLAGS)
+-CXXFLAGS := $(C_CXX_FLAGS) $(CXXFLAGS) $(TC_EXTRA_CXXFLAGS)
++CFLAGS := $(C_CXX_FLAGS) $(CFLAGS) $(TC_EXTRA_CFLAGS) $(PORT_CFLAGS)
++CXXFLAGS := $(C_CXX_FLAGS) $(CXXFLAGS) $(TC_EXTRA_CXXFLAGS) $(PORT_CXXFLAGS)
+ LFLAGS := $(LFLAGS) $(TC_EXTRA_LFLAGS)
+ 
+ #------ Reproducible build configuration ------

--- a/security/veracrypt/patches/patch-Setup_FreeBSD_veracrypt_desktop
+++ b/security/veracrypt/patches/patch-Setup_FreeBSD_veracrypt_desktop
@@ -1,0 +1,12 @@
+Index: Setup/FreeBSD/veracrypt.desktop
+--- Setup/FreeBSD/veracrypt.desktop.orig
++++ Setup/FreeBSD/veracrypt.desktop
+@@ -5,7 +5,7 @@
+ GenericName=VeraCrypt volume manager
+ Comment=Create and mount VeraCrypt encrypted volumes
+ Icon=veracrypt
+-Exec=/usr/bin/veracrypt %f
++Exec=${TRUEPREFIX}/bin/veracrypt %f
+ Categories=Security;Utility;Filesystem
+ Keywords=encryption,filesystem
+ Terminal=false

--- a/security/veracrypt/pkg/DESCR
+++ b/security/veracrypt/pkg/DESCR
@@ -1,0 +1,17 @@
+VeraCrypt is a free open source disk encryption software for
+Windows, Mac OSX and Linux.
+
+VeraCrypt main features:
+
+- Creates a virtual encrypted disk within a file and mounts it as a
+  real disk.
+- Encrypts an entire partition or storage device such as USB flash
+  drive or hard drive.
+- Encrypts a partition or drive where Windows is installed (pre-boot
+  authentication).
+- Encryption is automatic, real-time(on-the-fly) and transparent.
+- Parallelization and pipelining allow data to be read and written
+  as fast as if the drive was not encrypted.
+- Provides plausible deniability, in case an adversary forces you to
+  reveal the password: Hidden volume (steganography) and hidden
+  operating system.

--- a/security/veracrypt/pkg/PLIST
+++ b/security/veracrypt/pkg/PLIST
@@ -1,0 +1,7 @@
+@bin bin/veracrypt
+share/applications/veracrypt.desktop
+share/icons/hicolor/scalable/apps/veracrypt.svg
+share/pixmaps/
+share/pixmaps/veracrypt.xpm
+@tag update-desktop-database
+@tag gtk-update-icon-cache %D/share/icons/hicolor


### PR DESCRIPTION
Update from 1.25.9. Original maintainer's domain (tietoturvamies.fi) no longer resolves.

- 5 patches carried, 2 dropped (fixed upstream)
- Implements GetHostDevices() via sysctl hw.disknames
- exFAT auto-mount via direct mount.exfat call (bypasses OpenBSD mount_* naming mismatch)
- Adds RUN_DEPENDS on sysutils/exfat-fuse
- Tested on amd64/OpenBSD-CURRENT

See UPDATE file for full details.